### PR TITLE
fix: `./scripts/build-time` now uses node for mason.nvim tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,14 +44,14 @@
   "scripts": {
     "prepare": "husky",
     "setup": "run-s sh:build-time sh:build-wasm compile sh:relink sh:build-completions",
-    "dev": "run-s setup compile",                                
+    "dev": "run-s setup compile",
     "dev:watch": "run-s setup watch",
     "postinstall": "run-s sh:build-time",
     "prepack": "run-s lint:check generate-man-page sh:build-wasm compile",
     "compile": "tsc -b",
     "watch": "tsc -b -w",
     "sh:build-completions": "fish ./scripts/build-completions.fish",
-    "sh:build-time": "fish ./scripts/build-time.fish",
+    "sh:build-time": "node ./scripts/build-time",
     "sh:build-wasm": "fish ./scripts/build-fish-wasm.fish",
     "sh:relink": "fish ./scripts/relink-locally.fish",
     "sh:build-release": "fish ./scripts/build-release.fish",
@@ -63,7 +63,7 @@
     "lint:check": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix ",
     "lint:check-fix": "eslint . --ext .ts --fix-dry-run",
-    "generate-man-page": "mkdir -p ./docs/man && cat docs/MAN_FILE.md | npx marked-man --date \"$(date +'%e %B %+4Y')\"  --manual fish-lsp --section 1 --name fish-lsp > ./docs/man/fish-lsp.1"
+    "generate-man-page": "mkdir -p ./docs/man && cat docs/MAN_FILE.md | npx marked-man --date \"$(date)\"  --manual fish-lsp --section 1 --name fish-lsp > ./docs/man/fish-lsp.1"
   },
   "enabledApiProposals": [
     "inlineCompletions"
@@ -113,7 +113,7 @@
   "devDependencies": {
     "@commitlint/cli": "^19.6.0",
     "@commitlint/config-conventional": "^19.6.0",
-    "@esdmr/tree-sitter-fish": "3.5.2-0",
+    "@esdmr/tree-sitter-fish": "^3.5.2-0",
     "@tsconfig/node-lts": "^20.1.3",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.11.30",

--- a/scripts/build-time
+++ b/scripts/build-time
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+// Get the current date and time in YYYY-MM-DD HH:MM:SS format
+function getCurrentDateTime() {
+  const now = new Date();
+  
+  // Format date as YYYY-MM-DD
+  const date = now.toISOString().split('T')[0];
+  
+  // Format time as HH:MM:SS
+  const time = now.toTimeString().split(' ')[0];
+  
+  return `${date} ${time}`;
+}
+
+// Ensure the output directory exists
+function ensureOutDirExists() {
+  const outDir = path.resolve(__dirname, '../out');
+  if (!fs.existsSync(outDir)) {
+    fs.mkdirSync(outDir, { recursive: true });
+  }
+  return outDir;
+}
+
+// Write the build time to a file
+function writeBuildTime() {
+  const outDir = ensureOutDirExists();
+  const buildTimeFile = path.join(outDir, 'build-time.txt');
+  const buildTime = getCurrentDateTime();
+  
+  try {
+    fs.writeFileSync(buildTimeFile, `${buildTime}\n`);
+    console.log(`Build time recorded: ${buildTime}`);
+  } catch (error) {
+    console.error(`Error writing build time: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+// Execute the script
+writeBuildTime();

--- a/scripts/build-time.fish
+++ b/scripts/build-time.fish
@@ -1,5 +1,0 @@
-#!/usr/bin/env fish
-
-mkdir -p out
-# date +"%m-%d-%+4Y - %I:%M%p" > out/build-time.txt
-date +'%F %T' > out/build-time.txt


### PR DESCRIPTION
- [mason fish-lsp@1.0.8-4](https://github.com/mason-org/mason-registry/pull/8609) build fails.
  
- looks to be caused by fish not being included in container test env
   - ported `scripts/fish build-time.fish` to `node scripts/build-time` in [package.json](https://github.com/ndonfris/fish-lsp/blob/master/package.json)