### PR TITLE
fix: comment disable function diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,24 @@ Theoretically, the language-server should generally be compatible with almost an
 
 </details>
 <details>
+  <summary><b>kate</b></summary>
+
+  Configuration for [kate](https://kate-editor.org/)
+
+  ```json
+  {
+    "servers": {
+      "fish": {
+        "command": ["fish-lsp", "start"],
+        "url": "https://github.com/ndonfris/fish-lsp",
+        "highlightingModeRegex": "^fish$"
+      }
+    }
+  }
+  ```
+
+</details>
+<details>
   <summary><b>emacs</b></summary>
 
   Configuration using [eglot](https://github.com/joaotavora/eglot) (Built into Emacs 29+)

--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ set -gx fish_lsp_commit_characters
 set -gx fish_lsp_logfile
 
 # fish_lsp_all_indexed_paths <ARRAY>
-# fish file paths/workspaces to include as workspaces (default: ['/usr/share/fish', "$HOME/.config/fish"])
+# fish file paths/workspaces to include as workspaces (default: ["$HOME/.config/fish", '/usr/share/fish'])
 set -gx fish_lsp_all_indexed_paths
 
 # fish_lsp_modifiable_paths <ARRAY>
@@ -363,7 +363,7 @@ set -gx fish_lsp_modifiable_paths
 
 # fish_lsp_diagnostic_disable_error_codes <ARRAY>
 # disable diagnostics for matching error codes (default: [])
-# (options: 1001, 1002, 1003, 1004, 2001, 2002, 2003, 3001, 3002, 3003, 4001, 4002, 4003, 4004, 5001)
+# (options: 1001, 1002, 1003, 1004, 2001, 2002, 2003, 3001, 3002, 3003, 4001, 4002, 4003, 4004, 5001, 8001)
 set -gx fish_lsp_diagnostic_disable_error_codes
 
 # fish_lsp_max_background_files <NUMBER>

--- a/src/code-actions/disable-actions.ts
+++ b/src/code-actions/disable-actions.ts
@@ -134,12 +134,12 @@ export function handleDisableEntireFile(
     diagnosticsCounts.set(code, (diagnosticsCounts.get(code) || 0) + 1);
   });
 
-  const matchingDiagnostics: Array<ErrorCodes.codeTypes> = [];
+  const matchingDiagnostics: Array<ErrorCodes.CodeTypes> = [];
   diagnosticsCounts.forEach((count, code) => {
     if (count >= 5) {
       logger.log(`CODEACTION: Disabling ${count} ${code.toString()} diagnostics in file`);
     }
-    matchingDiagnostics.push(code as ErrorCodes.codeTypes);
+    matchingDiagnostics.push(code as ErrorCodes.CodeTypes);
   });
 
   if (matchingDiagnostics.length === 0) return results;

--- a/src/config.ts
+++ b/src/config.ts
@@ -76,7 +76,7 @@ export const ConfigSchema = z.object({
   fish_lsp_logfile: z.string().default(''),
 
   /** All workspaces/paths for the language-server to index */
-  fish_lsp_all_indexed_paths: z.array(z.string()).default(['/usr/share/fish', `${os.homedir()}/.config/fish`]),
+  fish_lsp_all_indexed_paths: z.array(z.string()).default([`${os.homedir()}/.config/fish`, '/usr/share/fish']),
 
   /** All workspace/paths that the language-server should be able to rename inside*/
   fish_lsp_modifiable_paths: z.array(z.string()).default([`${os.homedir()}/.config/fish`]),

--- a/src/diagnostics/comments-handler.ts
+++ b/src/diagnostics/comments-handler.ts
@@ -2,6 +2,7 @@ import { SyntaxNode } from 'web-tree-sitter';
 import { isComment } from '../utils/node-types';
 import { ErrorCodes } from './errorCodes';
 import { config } from '../config';
+import { Position } from 'vscode-languageserver';
 
 export type DiagnosticAction = 'enable' | 'disable';
 export type DiagnosticTarget = 'line' | 'next-line';
@@ -9,9 +10,15 @@ export type DiagnosticTarget = 'line' | 'next-line';
 export interface DiagnosticComment {
   action: DiagnosticAction;
   target: DiagnosticTarget;
-  codes: ErrorCodes.codeTypes[];
+  codes: ErrorCodes.CodeTypes[];
   lineNumber: number;
   invalidCodes?: string[]; // Track any invalid codes found during parsing
+}
+
+export interface DiagnosticState {
+  enabledCodes: Set<ErrorCodes.CodeTypes>;
+  comment: DiagnosticComment;
+  invalidCodes?: string[];
 }
 
 /**
@@ -36,8 +43,8 @@ export function isDiagnosticComment(node: SyntaxNode): boolean {
   return DIAGNOSTIC_COMMENT_REGEX.test(node.text.trim());
 }
 
-export function isValidErrorCode(code: number): code is ErrorCodes.codeTypes {
-  return Object.values(ErrorCodes).includes(code as ErrorCodes.codeTypes);
+export function isValidErrorCode(code: number): code is ErrorCodes.CodeTypes {
+  return Object.values(ErrorCodes).includes(code as ErrorCodes.CodeTypes);
 }
 
 /**
@@ -60,7 +67,7 @@ export function parseDiagnosticComment(node: SyntaxNode): DiagnosticComment | nu
     .map(codeStr => parseInt(codeStr, 10))
     .filter(code => !isNaN(code));
 
-  const validCodes: ErrorCodes.codeTypes[] = [];
+  const validCodes: ErrorCodes.CodeTypes[] = [];
   const invalidCodes: string[] = [];
 
   codeStrings.forEach((codeStr, idx) => {
@@ -75,43 +82,58 @@ export function parseDiagnosticComment(node: SyntaxNode): DiagnosticComment | nu
   return {
     action: action as DiagnosticAction,
     target: nextLine ? 'next-line' : 'line',
-    codes: validCodes,
+    codes: validCodes.length > 0 ? validCodes : ErrorCodes.allErrorCodes,
     lineNumber: node.startPosition.row,
-    invalidCodes:  invalidCodes.length > 0 ? invalidCodes : undefined,
+    invalidCodes: invalidCodes.length > 0 ? invalidCodes : undefined,
   };
 }
 
-function globalEnabledComments() {
-  const allComments = ErrorCodes.allErrorCodes;
-  if (config.fish_lsp_diagnostic_disable_error_codes.length > 0) {
-    return allComments.filter((comment) => !config.fish_lsp_diagnostic_disable_error_codes.includes(comment));
-  }
-  return allComments;
+/**
+ * Represents a diagnostic control point that affects code diagnostics
+ */
+interface DiagnosticControlPoint {
+  line: number;
+  action: DiagnosticAction;
+  codes: ErrorCodes.CodeTypes[];
+  isNextLine?: boolean;
 }
 
-export interface DiagnosticState {
-  enabledCodes: Set<ErrorCodes.codeTypes>;
-  comment: DiagnosticComment;
-  invalidCodes?: string[];
+/**
+ * Structure to track diagnostic state at a specific line
+ */
+interface LineState {
+  enabledCodes: Set<ErrorCodes.CodeTypes>;
 }
 
 export class DiagnosticCommentsHandler {
+  // Original stack-based state for compatibility during parsing
   private stateStack: DiagnosticState[] = [];
-  public enabledComments: ErrorCodes.codeTypes[] = globalEnabledComments();
-  public invalidCodeWarnings: Map<number, string[]> = new Map(); // lineNumber -> invalid codesublic invalidCodes: number[] = [];
+
+  // Track all control points (sorted by line number) for position-based lookups
+  private controlPoints: DiagnosticControlPoint[] = [];
+
+  // Map of line numbers to their effective states (calculated at the end)
+  private lineStateMap: Map<number, LineState> = new Map();
+
+  // Track invalid codes for reporting
+  public invalidCodeWarnings: Map<number, string[]> = new Map();
+
+  // Cached enabled comments for current state
+  public enabledComments: ErrorCodes.CodeTypes[] = [];
 
   constructor() {
     // Initialize with global state
     this.pushState(this.initialState);
+    this.enabledComments = Array.from(this.currentState.enabledCodes);
   }
 
   private get initialState(): DiagnosticState {
     return {
-      enabledCodes: new Set(this.enabledComments),
+      enabledCodes: new Set(this.globalEnabledCodes()),
       comment: {
         action: 'enable',
         target: 'line',
-        codes: this.enabledComments,
+        codes: this.globalEnabledCodes(),
         lineNumber: -1,
       },
     };
@@ -119,6 +141,15 @@ export class DiagnosticCommentsHandler {
 
   private get currentState(): DiagnosticState {
     return this.stateStack[this.stateStack.length - 1]!;
+  }
+
+  private globalEnabledCodes(): ErrorCodes.CodeTypes[] {
+    if (config.fish_lsp_diagnostic_disable_error_codes.length > 0) {
+      return ErrorCodes.allErrorCodes.filter(
+        code => !config.fish_lsp_diagnostic_disable_error_codes.includes(code),
+      );
+    }
+    return ErrorCodes.allErrorCodes;
   }
 
   private pushState(state: DiagnosticState) {
@@ -132,6 +163,10 @@ export class DiagnosticCommentsHandler {
     }
   }
 
+  /**
+   * Process a node for diagnostic comments
+   * This maintains both the stack state and records control points
+   */
   public handleNode(node: SyntaxNode): void {
     // Clean up any expired next-line comments
     this.cleanupNextLineComments(node.startPosition.row);
@@ -149,15 +184,13 @@ export class DiagnosticCommentsHandler {
       this.invalidCodeWarnings.set(comment.lineNumber, comment.invalidCodes);
     }
 
+    // Process the comment for both backward compatibility and position-based lookups
     this.processComment(comment);
   }
 
   private processComment(comment: DiagnosticComment) {
+    // Update stack-based state (for backward compatibility)
     const newEnabledCodes = new Set(this.currentState.enabledCodes);
-
-    if (['enable', 'disable'].includes(comment.action) && comment.codes.length === 0) {
-      comment.codes = globalEnabledComments();
-    }
 
     if (comment.action === 'disable') {
       comment.codes.forEach(code => newEnabledCodes.delete(code));
@@ -169,8 +202,19 @@ export class DiagnosticCommentsHandler {
       enabledCodes: newEnabledCodes,
       comment,
       invalidCodes: comment.invalidCodes,
-
     };
+
+    // Update control points for position-based lookups
+    const controlPoint: DiagnosticControlPoint = {
+      line: comment.lineNumber,
+      action: comment.action,
+      codes: comment.codes,
+      isNextLine: comment.target === 'next-line',
+    };
+
+    this.controlPoints.push(controlPoint);
+    // Keep control points sorted by line number
+    this.controlPoints.sort((a, b) => a.line - b.line);
 
     if (comment.target === 'next-line') {
       // For next-line, we'll push a new state that will be popped after the line
@@ -196,12 +240,132 @@ export class DiagnosticCommentsHandler {
     }
   }
 
-  public isCodeEnabled(code: ErrorCodes.codeTypes): boolean {
-    // ErrorCodes.allErrorCodes.filter(e => !this.currentState.enabledCodes.has(e))
-    return !!this.enabledComments.find(comment => comment === code);
+  /**
+   * This method is called when all nodes have been processed
+   * It computes the effective state for each line in the document
+   */
+  public finalizeStateMap(maxLine: number): void {
+    // Start with initial state
+    let currentState: LineState = {
+      enabledCodes: new Set(this.globalEnabledCodes()),
+    };
+
+    // Process all regular control points first
+    const regularPoints = this.controlPoints.filter(p => !p.isNextLine);
+    const nextLinePoints: Map<number, DiagnosticControlPoint[]> = new Map();
+
+    // Group next-line control points by target line
+    for (const point of this.controlPoints) {
+      if (point.isNextLine) {
+        const targetLine = point.line + 1;
+        const existing = nextLinePoints.get(targetLine) || [];
+        existing.push({ ...point, line: targetLine });
+        nextLinePoints.set(targetLine, existing);
+      }
+    }
+
+    // Build line by line state
+    for (let line = 0; line <= maxLine; line++) {
+      // Apply regular control points for this line
+      for (const point of regularPoints) {
+        if (point.line <= line) {
+          this.applyControlPointToState(currentState, point);
+        }
+      }
+
+      // Save the state before applying next-line directives
+      const baseState = {
+        enabledCodes: new Set(currentState.enabledCodes),
+      };
+
+      // Apply next-line directives for this line only
+      const nextLineDirs = nextLinePoints.get(line) || [];
+      for (const directive of nextLineDirs) {
+        this.applyControlPointToState(currentState, directive);
+      }
+
+      // Store state for this line
+      this.lineStateMap.set(line, {
+        enabledCodes: new Set(currentState.enabledCodes),
+      });
+
+      // Restore base state after next-line directives
+      if (nextLineDirs.length > 0) {
+        currentState = baseState;
+      }
+    }
   }
 
-  // For debugging/testing
+  private applyControlPointToState(state: LineState, point: DiagnosticControlPoint): void {
+    if (point.action === 'disable') {
+      // Disable specified codes
+      for (const code of point.codes) {
+        state.enabledCodes.delete(code);
+      }
+    } else {
+      // Enable specified codes
+      for (const code of point.codes) {
+        state.enabledCodes.add(code);
+      }
+    }
+  }
+
+  public isCodeEnabledAtNode(code: ErrorCodes.CodeTypes, node: SyntaxNode): boolean {
+    const position = { line: node.startPosition.row, character: node.startPosition.column };
+    return this.isCodeEnabledAtPosition(code, position);
+  }
+
+  /**
+   * Check if a specific diagnostic code is enabled at a given position
+   * Will use the pre-computed state if available, otherwise computes on-demand
+   */
+  public isCodeEnabledAtPosition(code: ErrorCodes.CodeTypes, position: Position): boolean {
+    if (this.lineStateMap.has(position.line)) {
+      // Use pre-computed state if available
+      const state = this.lineStateMap.get(position.line)!;
+      return state.enabledCodes.has(code);
+    }
+
+    // Compute state on-demand if not pre-computed
+    return this.computeStateAtPosition(position).enabledCodes.has(code);
+  }
+
+  /**
+   * Compute state at a position on-demand (used if finalizeStateMap hasn't been called)
+   */
+  private computeStateAtPosition(position: Position): LineState {
+    // Start with global state
+    const state: LineState = {
+      enabledCodes: new Set(this.globalEnabledCodes()),
+    };
+
+    // Apply all regular control points up to this position
+    for (const point of this.controlPoints) {
+      if (point.line > position.line) {
+        break; // Skip control points after this position
+      }
+
+      if (!point.isNextLine && point.line <= position.line) {
+        this.applyControlPointToState(state, point);
+      }
+
+      // Apply next-line directives for the specific line
+      if (point.isNextLine && point.line + 1 === position.line) {
+        this.applyControlPointToState(state, { ...point, line: position.line });
+      }
+    }
+
+    return state;
+  }
+
+  /**
+   * Check if a specific diagnostic code is enabled in the current state
+   * This is for backward compatibility during parsing
+   */
+  public isCodeEnabled(code: ErrorCodes.CodeTypes): boolean {
+    return this.currentState.enabledCodes.has(code);
+  }
+
   public getStackDepth(): number {
     return this.stateStack.length;
   }
@@ -210,6 +374,9 @@ export class DiagnosticCommentsHandler {
     return this.currentState;
   }
 
+  /**
+   * For debugging/testing - get verbose state information
+   */
   public getCurrentStateVerbose() {
     const currentState = this.getCurrentState();
     const disabledCodes = ErrorCodes.allErrorCodes.filter(e => !currentState.enabledCodes.has(e));
@@ -222,8 +389,13 @@ export class DiagnosticCommentsHandler {
         return item;
       })
       .join(' | ');
+
     const invalidCodes = Array.from(this.invalidCodeWarnings.entries())
       .map(([line, codes]) => `${line}: ${codes.join(' | ')}`);
+
+    const lineStates = Array.from(this.lineStateMap.entries())
+      .map(([line, state]) => `Line ${line}: ${Array.from(state.enabledCodes).length} enabled codes`);
+
     return {
       depth: this.getStackDepth(),
       enabledCodes: enabledCodes,
@@ -234,6 +406,8 @@ export class DiagnosticCommentsHandler {
         codes: currentState.comment?.codes.join(' | '),
         lineNumber: currentState.comment.lineNumber,
       },
+      controlPoints: this.controlPoints.length,
+      lineStates: lineStates.slice(0, 10), // Show first 10 for brevity
     };
   }
 }

--- a/src/diagnostics/errorCodes.ts
+++ b/src/diagnostics/errorCodes.ts
@@ -23,26 +23,29 @@ export namespace ErrorCodes {
 
   export const argparseMissingEndStdin = 5001;
 
-  export type codeTypes =
+  export const invalidDiagnosticCode = 8001;
+
+  export type CodeTypes =
     1001 | 1002 | 1003 | 1004 |
     2001 | 2002 | 2003 |
     3001 | 3002 | 3003 |
     4001 | 4002 | 4003 | 4004 |
-    5001;
+    5001 |
+    8001;
 
   export type CodeValueType = {
     severity: DiagnosticSeverity;
-    code: codeTypes;
+    code: CodeTypes;
     codeDescription: CodeDescription;
     source: 'fish-lsp';
     message: string;
   };
 
   export type DiagnosticCode = {
-    [k in codeTypes]: CodeValueType;
+    [k in CodeTypes]: CodeValueType;
   };
 
-  export const codes: { [k in codeTypes]: CodeValueType } = {
+  export const codes: { [k in CodeTypes]: CodeValueType } = {
     [missingEnd]: {
       severity: DiagnosticSeverity.Error,
       code: missingEnd,
@@ -148,10 +151,17 @@ export namespace ErrorCodes {
       source: 'fish-lsp',
       message: 'argparse missing end of stdin',
     },
+    [invalidDiagnosticCode]: {
+      severity: DiagnosticSeverity.Warning,
+      code: invalidDiagnosticCode,
+      codeDescription: { href: 'https://github.com/ndonfris/fish-lsp/wiki/Diagnostic-Error-Codes' },
+      source: 'fish-lsp',
+      message: 'Invalid diagnostic control code',
+    },
   };
 
   /** All error codes */
-  export const allErrorCodes = Object.values(codes).map((diagnostic) => diagnostic.code) as codeTypes[];
+  export const allErrorCodes = Object.values(codes).map((diagnostic) => diagnostic.code) as CodeTypes[];
 
   export function getSeverityString(severity: DiagnosticSeverity | undefined): string {
     if (!severity) return '';
@@ -169,8 +179,8 @@ export namespace ErrorCodes {
     }
   }
 
-  export function getDiagnostic(code: codeTypes | number): CodeValueType {
-    if (typeof code === 'number') return codes[code as codeTypes];
+  export function getDiagnostic(code: CodeTypes | number): CodeValueType {
+    if (typeof code === 'number') return codes[code as CodeTypes];
     return codes[code];
   }
 }

--- a/src/diagnostics/invalid-error-code.ts
+++ b/src/diagnostics/invalid-error-code.ts
@@ -1,0 +1,102 @@
+import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver';
+import { SyntaxNode } from 'web-tree-sitter';
+import { ErrorCodes } from './errorCodes';
+import { isComment } from '../utils/node-types';
+import { logger } from '../logger';
+
+// More precise regex to capture exact positions of code numbers
+// const DIAGNOSTIC_CODES_REGEX = /^#\s*@fish-lsp-(enable|disable)(?:-(next-line))?\s*((?:\d+\s*)*)$/;
+
+// interface InvalidCode {
+//   code: string;
+//   startIndex: number;
+//   endIndex: number;
+// }
+
+// For initial screening of the comment
+const DIAGNOSTIC_COMMENT_REGEX = /^#\s*@fish-lsp-(disable|enable)(?:-(next-line))?\s/;
+
+export function isPossibleDiagnosticComment(node: SyntaxNode): boolean {
+  if (!isComment(node)) return false;
+  return DIAGNOSTIC_COMMENT_REGEX.test(node.text.trim());
+}
+
+// For initial screening of the comment
+// const DIAGNOSTIC_COMMENT_REGEX = /^#\s*@fish-lsp-(disable|enable)(?:-(next-line))?\s/;
+
+// Function to find codes with their positions
+function findCodes(text: string): {code: string; startIndex: number;}[] {
+  // Find where the codes section starts (after the directive)
+  const directiveMatch = text.match(/@fish-lsp-(?:disable|enable)(?:-next-line)?/);
+  if (!directiveMatch) return [];
+
+  const codesStart = directiveMatch.index! + directiveMatch[0].length;
+  const codesSection = text.slice(codesStart);
+
+  // Find all code tokens in the codes section
+  const result: {code: string; startIndex: number;}[] = [];
+  const codeRegex = /(\d+)/g;
+  let match;
+
+  while ((match = codeRegex.exec(codesSection)) !== null) {
+    result.push({
+      code: match[0],
+      startIndex: codesStart + match.index,
+    });
+  }
+
+  logger.log('Found codes:', result, 'on text:', text);
+  logger.log('Directive:', directiveMatch);
+  return result;
+}
+
+export function detectInvalidDiagnosticCodes(node: SyntaxNode): Diagnostic[] {
+  // Early return if not a diagnostic comment
+  if (!isComment(node)) return [];
+
+  const text = node.text.trim();
+  if (!DIAGNOSTIC_COMMENT_REGEX.test(text)) return [];
+
+  // Find all code numbers with their positions
+  const codePositions = findCodes(text);
+  const diagnostics: Diagnostic[] = [];
+
+  for (const { code, startIndex } of codePositions) {
+    const codeNum = parseInt(code, 10) as ErrorCodes.CodeTypes;
+
+    // Check if it's a valid error code
+    if (isNaN(codeNum) || !ErrorCodes.allErrorCodes.includes(codeNum)) {
+      // Create diagnostic for this invalid code
+      diagnostics.push({
+        severity: DiagnosticSeverity.Warning,
+        range: {
+          start: {
+            line: node.startPosition.row,
+            character: node.startPosition.column + startIndex,
+          },
+          end: {
+            line: node.startPosition.row,
+            character: node.startPosition.column + startIndex + code.length,
+          },
+        },
+        message: `Invalid diagnostic code: '${code}'. Valid codes are: ${ErrorCodes.allErrorCodes.join(', ')}.`,
+        source: 'fish-lsp',
+        code: 'invalidDiagnosticCode',
+        data: {
+          node,
+          invalidCode: code,
+        },
+      });
+    }
+  }
+
+  return diagnostics;
+}
+
+// Function to add to the validate.ts getDiagnostics function
+export function checkForInvalidDiagnosticCodes(node: SyntaxNode): Diagnostic[] {
+  if (isPossibleDiagnosticComment(node)) {
+    return detectInvalidDiagnosticCodes(node);
+  }
+  return [];
+}

--- a/src/diagnostics/invalid-error-code.ts
+++ b/src/diagnostics/invalid-error-code.ts
@@ -5,15 +5,6 @@ import { isComment } from '../utils/node-types';
 import { logger } from '../logger';
 
 // More precise regex to capture exact positions of code numbers
-// const DIAGNOSTIC_CODES_REGEX = /^#\s*@fish-lsp-(enable|disable)(?:-(next-line))?\s*((?:\d+\s*)*)$/;
-
-// interface InvalidCode {
-//   code: string;
-//   startIndex: number;
-//   endIndex: number;
-// }
-
-// For initial screening of the comment
 const DIAGNOSTIC_COMMENT_REGEX = /^#\s*@fish-lsp-(disable|enable)(?:-(next-line))?\s/;
 
 export function isPossibleDiagnosticComment(node: SyntaxNode): boolean {
@@ -21,13 +12,10 @@ export function isPossibleDiagnosticComment(node: SyntaxNode): boolean {
   return DIAGNOSTIC_COMMENT_REGEX.test(node.text.trim());
 }
 
-// For initial screening of the comment
-// const DIAGNOSTIC_COMMENT_REGEX = /^#\s*@fish-lsp-(disable|enable)(?:-(next-line))?\s/;
-
 // Function to find codes with their positions
 function findCodes(text: string): {code: string; startIndex: number;}[] {
   // Find where the codes section starts (after the directive)
-  const directiveMatch = text.match(/@fish-lsp-(?:disable|enable)(?:-next-line)?/);
+  const directiveMatch = text.match(/@fish-lsp-(?:disable|enable)(?:-next-line)?/); // remove leading comment
   if (!directiveMatch) return [];
 
   const codesStart = directiveMatch.index! + directiveMatch[0].length;

--- a/src/snippets/fishlspEnvVariables.json
+++ b/src/snippets/fishlspEnvVariables.json
@@ -31,7 +31,7 @@
   },
   {
     "name": "fish_lsp_diagnostic_disable_error_codes",
-    "description": "disable diagnostics for matching error codes (options: 1001, 1002, 1003, 1004, 2001, 2002, 2003, 3001, 3002, 3003) (default: [])",
+    "description": "disable diagnostics for matching error codes (options: 1001, 1002, 1003, 1004, 2001, 2002, 2003, 3001, 3002, 3003, 4001, 4002, 4003, 4004, 5001, 8001) (default: [])",
     "valueType": "array"
   },
   {

--- a/src/utils/completion/comment-completions.ts
+++ b/src/utils/completion/comment-completions.ts
@@ -95,13 +95,13 @@ function getCommentDiagnostics(line: string, lineNumber: number) {
     .map(codeStr => parseInt(codeStr, 10))
     .filter(code => !isNaN(code));
 
-  const validCodes: ErrorCodes.codeTypes[] = [];
+  const validCodes: ErrorCodes.CodeTypes[] = [];
   const invalidCodes: string[] = [];
 
   codeStrings.forEach((codeStr, idx) => {
     const code = parsedCodes[idx];
     if (code && !isNaN(code) && isValidErrorCode(code)) {
-      validCodes.push(code as ErrorCodes.codeTypes);
+      validCodes.push(code as ErrorCodes.CodeTypes);
     } else {
       invalidCodes.push(codeStr);
     }

--- a/src/utils/completion/static-items.ts
+++ b/src/utils/completion/static-items.ts
@@ -802,6 +802,7 @@ const disableDiagnostics = Object.values(ErrorCodes.codes).map((diagnostic) => {
   return {
     label: `${diagnostic.code}`,
     detail: diagnostic.message,
+    useDocAsDetail: true,
     documentation: [
       `# Error code: ${diagnostic.code}`,
       md.separator(),


### PR DESCRIPTION
- `# @fish-lsp-disable` & `# @fish-lsp-enable` now work for function symbols (#74)
- added diagnostic error 8001 for unrecognized diagnostic error code
- minor changes to README (added `kate` to clients)
- updated snippets.json to reflect new `ErrorCode.CodeTypes`