### PR TITLE
fix: update config from init_options before server start

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,9 +18,8 @@ export function startServer() {
   connection.onInitialize(
     async (params: InitializeParams): Promise<InitializeResult> => {
       // connection.console.log(`Initialized server FISH-LSP with ${JSON.stringify(params, null, 2)}`);
-      const server = await FishServer.create(connection, params);
-      server.register(connection);
-      return server.initialize(params);
+      const { initializeResult } = await FishServer.create(connection, params);
+      return initializeResult;
     },
   );
   connection.listen();
@@ -68,9 +67,7 @@ async function timeServerStartup() {
       rootUri: process.cwd(),
       capabilities: {},
     };
-    server = await FishServer.create(connection, startupParams);
-    server.register(connection);
-    server.initialize(startupParams);
+    ({ server } = await FishServer.create(connection, startupParams));
     connection.listen();
     return server;
   }, 'Server Start Time');


### PR DESCRIPTION
### Problem

My `fish_lsp_all_indexed_paths` initialization option wasn't getting picked up fish-lsp. This was because the background analysis was kicked off before the config was updated from the initialization options.

### Solution

Now we setup the config and client capabilities with the initializations before anything, and then we setup the LSP handlers and kick off the background analysis and indexing afterwards.
