### PR TITLE
Fix/variable refs #92 && invalid code-actions #91 

### DIFF
--- a/src/code-actions/code-action-handler.ts
+++ b/src/code-actions/code-action-handler.ts
@@ -123,12 +123,13 @@ export function createCodeActionHandler(docs: LspDocuments, analyzer: Analyzer) 
     const uri = uriToPath(params.textDocument.uri);
     const document = docs.get(uri);
     if (!document || !uri) return [];
-    logger.log('onCodeAction', { uri });
 
     const results: CodeAction[] = [];
 
     // only process diagnostics from the fish-lsp source
-    const diagnostics = params.context.diagnostics.filter(d => d.source === 'fish-lsp');
+    const diagnostics = params.context.diagnostics
+      .filter(d => !!d?.severity)
+      .filter(d => d.source === 'fish-lsp');
 
     // Check what kinds of actions are requested
     const onlyRefactoring = params.context.only?.some(kind => kind.startsWith('refactor'));

--- a/src/diagnostics/error-codes.ts
+++ b/src/diagnostics/error-codes.ts
@@ -246,6 +246,10 @@ export namespace ErrorCodes {
     }
   }
 
+  export function codeTypeGuard(code: CodeTypes | number | string | undefined): code is CodeTypes {
+    return typeof code === 'number' && code >= 1000 && code < 10000 && allErrorCodes.includes(code as CodeTypes);
+  }
+
   export function getDiagnostic(code: CodeTypes | number): CodeValueType {
     if (typeof code === 'number') return codes[code as CodeTypes];
     return codes[code];

--- a/src/parsing/reference-comparator.ts
+++ b/src/parsing/reference-comparator.ts
@@ -285,11 +285,11 @@ export const isSymbolReference = (
   if (!isInValidScope(ctx)) return false;
 
   // Validate function name matching
-  if (!matchesFunctionName(ctx)) return false;
+  if (symbol.isFunction() && !matchesFunctionName(ctx)) return false;
 
   // Check complete command references
   const parentNode = node.parent ? findParentCommand(node) : null;
-  if (parentNode && isCommandWithName(parentNode, 'complete')) {
+  if (parentNode && isCommandWithName(parentNode, 'complete') && !isVariable(node)) {
     return checkCompleteCommandReference(ctx);
   }
 

--- a/src/references.ts
+++ b/src/references.ts
@@ -630,7 +630,7 @@ function* getChildNodesOptimized(symbol: FishSymbol, doc: LspDocument): Generato
     if (!current) continue;
 
     if (
-      skipNodes.some(s =>
+      skipNodes && skipNodes.some(s =>
         containsNode(s, current) || s.equals(current) && !isProgram(current),
       )) {
       continue;
@@ -823,8 +823,8 @@ export const getFilteredLocalSymbols = (definitionSymbol: FishSymbol, doc: LspDo
   return analyzer.getFlatDocumentSymbols(doc.uri)
     .filter(s =>
       s.isLocal()
-        && s.name === definitionSymbol.name
-        && s.kind === definitionSymbol.kind
-        && !s.equals(definitionSymbol),
+      && s.name === definitionSymbol.name
+      && s.kind === definitionSymbol.kind
+      && !s.equals(definitionSymbol),
     );
 };


### PR DESCRIPTION
Fixes [variables not considered references in `complete` arguments](https://github.com/ndonfris/fish-lsp/issues/92), when `complete` uses the `variable_expansion`

Example:

```fish
set -l arq_subcommands activateLicense refreshLicense ....
#      ^^^^^^^^^^^^^^^ getReferences()
complete -c arqc -n "not __fish_seen_subcommand_from $arq_subcommands" -a "$arq_subcommands"
# 2 references                                        ^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^^
```

> In the example above there is 3 total references for the `arq_subcommands` variable.
>
> The definition itself is 1 reference, and the other 2 are seen in the `complete` command's arguments 

___

Fixes [code-action error](https://github.com/ndonfris/fish-lsp/issues/91) code in [VSCode extension](https://github.com/ndonfris/vscode-fish-lsp) when

```fish
#
# @fish-lsp-disable 400
```

When cursor is typing an error code to disable, e.g., `400` (which would currently be an invalid diagnostic code to disable)

___


closes #91 #92 