### PR TITLE
feat: support es2025 iterators and minor tweaks to symbol utilities for #96

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "@types/eslint": "^9.6.1",
     "@types/jest": "^29.5.12",
     "@types/jsdom": "^21.1.7",
-    "@types/node": "^22.13.14",
+    "@types/node": "^24.0.14",
     "@types/node-fetch": "^2.6.12",
     "@typescript-eslint/eslint-plugin": "^7.0.1",
     "@typescript-eslint/parser": "^7.4.0",
@@ -181,6 +181,6 @@
     "ts-node": "^10.9.2",
     "tsc": "^2.0.4",
     "tsx": "^4.19.3",
-    "typescript": "5.5.4"
+    "typescript": "^5.8.3"
   }
 }

--- a/src/parsing/options.ts
+++ b/src/parsing/options.ts
@@ -235,7 +235,7 @@ export class Option {
   }
 
   equals(node: SyntaxNode, allowEquals = false): boolean {
-    if (!isOption(node)) false;
+    if (!isOption(node)) return false;
     const text = allowEquals ? node.text.slice(0, node.text.indexOf('=')) : node.text;
     if (isLongOption(node)) return this.matchesLongFlag(text);
     if (isShortOption(node) && this.unixOptions.length >= 1) return this.matchesUnixFlag(text);

--- a/src/utils/definition-scope.ts
+++ b/src/utils/definition-scope.ts
@@ -24,7 +24,15 @@ export class DefinitionScope {
     return new DefinitionScope(scopeNode, scopeTag);
   }
 
+  /**
+   * Add checks for issue mentioned at: https://github.com/ndonfris/fish-lsp/issues/96
+   */
   containsPosition(position: Position) {
+    // Global and universal scopes are always considered to contain all positions
+    if (this.tag >= DefinitionScope.ScopeTags.global) return true;
+    // If there is no scope node, we cannot determine containment
+    if (!this.scopeNode) return false;
+    // Check if the position is within the range of the scope node
     return isPositionWithinRange(position, getRange(this.scopeNode));
   }
 

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,7 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "target": "ES2023",
     "downlevelIteration": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "@tsconfig/node22/tsconfig.json",
   "compilerOptions": {
+    //"target": "ES2022",
+    "lib": ["ESNext"],
     "incremental": true,
     "esModuleInterop": true,
     "importHelpers": false, // causes tslib dependency which might not be available on node

--- a/yarn.lock
+++ b/yarn.lock
@@ -1151,12 +1151,12 @@
   dependencies:
     undici-types "~6.20.0"
 
-"@types/node@^22.13.14":
-  version "22.13.14"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.13.14.tgz#70d84ec91013dcd2ba2de35532a5a14c2b4cc912"
-  integrity sha512-Zs/Ollc1SJ8nKUAgc7ivOEdIBM8JAKgrqqUYi2J997JuKO7/tpQC+WCetQ1sypiKCQWHdvdg9wBNpUPEWZae7w==
+"@types/node@^24.0.14":
+  version "24.0.14"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.0.14.tgz#6e3d4fb6d858c48c69707394e1a0e08ce1ecc1bc"
+  integrity sha512-4zXMWD91vBLGRtHK3YbIoFMia+1nqEz72coM42C5ETjnNCa/heoj7NT1G67iAfOqMmcfhuCZ4uNpyz8EjlAejw==
   dependencies:
-    undici-types "~6.20.0"
+    undici-types "~7.8.0"
 
 "@types/normalize-package-data@^2.4.1":
   version "2.4.4"
@@ -5583,10 +5583,10 @@ typed-array-length@^1.0.7:
     possible-typed-array-names "^1.0.0"
     reflect.getprototypeof "^1.0.6"
 
-typescript@5.5.4:
-  version "5.5.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.4.tgz#d9852d6c82bad2d2eda4fd74a5762a8f5909e9ba"
-  integrity sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==
+typescript@^5.8.3:
+  version "5.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.3.tgz#92f8a3e5e3cf497356f4178c34cd65a7f5e8440e"
+  integrity sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==
 
 unbox-primitive@^1.1.0:
   version "1.1.0"
@@ -5602,6 +5602,11 @@ undici-types@~6.20.0:
   version "6.20.0"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.20.0.tgz#8171bf22c1f588d1554d55bf204bc624af388433"
   integrity sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==
+
+undici-types@~7.8.0:
+  version "7.8.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.8.0.tgz#de00b85b710c54122e44fbfd911f8d70174cd294"
+  integrity sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==
 
 unicorn-magic@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
## PR Goal

Allow `ES2025` language features to be accessible in the project's source code. New array-like methods on `Iterator`/`Generator` objects will be extremely useful during future development. 

## Change Summary

- update [typescript](https://github.com/ndonfris/fish-lsp/blob/d546fbf714c4313b65e15891d388b33c2394d983/package.json#L184) `"devDependency"` version to allow `node@v1.22.22` to build a target from `"lib": ["ESNext"]` in [`tsconfig.json`](https://github.com/ndonfris/fish-lsp/blob/d546fbf714c4313b65e15891d388b33c2394d983/tsconfig.json#L5) 

- add missing `return` statement to `Option.equals()` in [`src/parsing/options.ts`](https://github.com/ndonfris/fish-lsp/blob/d546fbf714c4313b65e15891d388b33c2394d983/tsconfig.json#L5)

- add [`DefinitionScope.containsPosition()` non-nullish check](https://github.com/ndonfris/fish-lsp/blob/d546fbf714c4313b65e15891d388b33c2394d983/src/utils/definition-scope.ts#L30) to suppress issue causing bug mentioned in #96 

## Notes

Since we are now using the `typescript@latest` version, which does not satisfy version requirements for the current devDependencies `eslint` tooling, we will need to update the [`.eslintrc.cjs` config](https://github.com/ndonfris/fish-lsp/blob/d546fbf714c4313b65e15891d388b33c2394d983/.eslintrc.cjs) in a future PR. This was considered a non-essential QOL improvement at this time because `eslint` still appears to work without exiting unsuccessfully.      

Minor tweaks to utilities used by [`FishSymbol`](https://github.com/ndonfris/fish-lsp/blob/d546fbf714c4313b65e15891d388b33c2394d983/src/parsing/symbol.ts) objects were also included in this PR. 