### PR TITLE
fix: read parsing issue #96  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ coverage
 .bun
 dist
 build
+*.cast
+*.gif
+

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "engines": {
     "node": ">=22.0.0"
   },
+  "engineStrict": true,
   "directories": {
     "bin": "./bin/fish-lsp",
     "man": "./docs/man/"

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -799,11 +799,15 @@ export class Analyzer {
   }
 
   /**
-   * Finds the rootnode given a LspDocument. If useCache is set to false, it will
-   * use the parser to parse the document passed in, and then return the rootNode.
+   * gets/finds the rootNode given a DocumentUri. if cached it will return the root from the cache,
+   * Otherwise it will analyze the path and return the root node, which might not be possible if the path
+   * is not readable or the file does not exist.
    */
   getRootNode(documentUri: string): SyntaxNode | undefined {
-    return this.cache.getParsedTree(documentUri)?.rootNode;
+    if (this.cache.hasUri(documentUri)) {
+      return this.cache.getRootNode(documentUri)!;
+    }
+    return this.analyzePath(uriToPath(documentUri))?.root;
   }
 
   /**

--- a/src/parsing/set.ts
+++ b/src/parsing/set.ts
@@ -98,6 +98,20 @@ export function setModifierDetailDescriptor(node: SyntaxNode) {
   return ['', exportedStr].filter(Boolean).join('; ');
 }
 
+// function findParentScopeNode(commandNode: SyntaxNode, modifier: ModifierScopeTag): SyntaxNode {
+//   switch (modifier) {
+//     case 'universal':
+//     case 'global':
+//     case 'function':
+//       return findParentWithFallback(commandNode, (n) => isFunctionDefinition(n))
+//     case 'inherit':
+//     case 'local':
+//     default:
+//       return findParentWithFallback(commandNode, (n) => isScope(n))
+//   }
+//
+// }
+
 export function processSetCommand(document: LspDocument, node: SyntaxNode, children: FishSymbol[] = []) {
   /** skip `set -q/--query` */
   if (!isSetDefinition(node)) return [];

--- a/src/parsing/symbol.ts
+++ b/src/parsing/symbol.ts
@@ -552,7 +552,9 @@ export class FishSymbol {
   }
 }
 
-export const SetModifierToScopeTag = (modifier: Option) => {
+export type ModifierScopeTag = 'universal' | 'global' | 'function' | 'local' | 'inherit';
+
+export const SetModifierToScopeTag = (modifier: Option): ModifierScopeTag => {
   switch (true) {
     case modifier.isOption('-U', '--universal'):
       return 'universal';

--- a/src/utils/node-types.ts
+++ b/src/utils/node-types.ts
@@ -66,6 +66,7 @@ export function isFunctionDefinition(node: SyntaxNode): boolean {
 
 /**
  * checks for all fish types of SyntaxNodes that are commands.
+ * This includes: `command`, `test_command`, and `command_substitution`.
  */
 export function isCommand(node: SyntaxNode): boolean {
   return [
@@ -349,6 +350,22 @@ export function isPipe(node: SyntaxNode): boolean {
   return node.type === 'pipe';
 }
 
+// Makes sure that the node we are assuming is a variable name (for a command that creates a variable definition from its arguments)
+// is not a token that fish uses for other purposes, like `-`, `--`, `\\`, `;`, or `(`
+export function isInvalidVariableName(node: SyntaxNode): boolean {
+  switch (node.text.trim()) {
+    case '':
+    case '-':
+    case '--':
+    case '\\':
+    case ';':
+    case '(':
+      return true; // these are not valid variable names
+    default:
+      return false; // all other names are valid
+  }
+}
+
 export function gatherSiblingsTillEol(node: SyntaxNode): SyntaxNode[] {
   const siblings = [];
   let next = node.nextSibling;
@@ -552,6 +569,20 @@ export function findParent(node: SyntaxNode, callbackfn: (n: SyntaxNode) => bool
     currentNode = currentNode.parent!;
   }
   return null;
+}
+
+/**
+ * Find the parent node that matches the callback function, or return the root node of the tree
+ */
+export function findParentWithFallback(node: SyntaxNode, callbackfn: (n: SyntaxNode) => boolean) {
+  let currentNode: SyntaxNode | null = node;
+  while (currentNode !== null) {
+    if (callbackfn(currentNode)) {
+      return currentNode;
+    }
+    currentNode = currentNode.parent;
+  }
+  return node.tree.rootNode;
 }
 
 export function hasParentFunction(node: SyntaxNode) {


### PR DESCRIPTION
## Summary

```fish
read -P '...' some_var
```

Previously caused the server to crash because of the `DefinitionScope.scopeNode` was `undefined` for certain read `FishSymbol`. This PR removes this issue, and makes the `DefinitionScope.scopeNode` created by the symbols generated in [`processNestedTree()`](https://github.com/ndonfris/fish-lsp/blob/42c1a9477538e5850a95373986572356a68bf018/src/parsing/symbol.ts#L716) to be non-nullish.

<details>
<summary>Demo test of fix</summary>

![Image](https://github.com/user-attachments/assets/63f26f43-594d-46eb-97e7-00d856e76ed4)

</details>

## Notes

- `FishSymbol` variables are now checked to not be named values like: [`-`, `--`, `(...)`, etc.](https://github.com/ndonfris/fish-lsp/blob/42c1a9477538e5850a95373986572356a68bf018/src/utils/node-types.ts#L577)

- `analyzer.getRootNode()` now will attempt to get a `Tree.rootNode` by parsing the uri passed into it, when the document is not already cached

- `package.json` now includes [`"engineStrict": true`](https://github.com/ndonfris/fish-lsp/blob/42c1a9477538e5850a95373986572356a68bf018/package.json#L26) 

## Other Links

- issue #96: [`mention 1`](https://github.com/ndonfris/fish-lsp/issues/96#issuecomment-3089693332), [`mention 2`](https://github.com/ndonfris/fish-lsp/issues/96#issuecomment-3089570489)