### PR TITLE
fix: `FishSymbol` w/ `set --function` definition `scopeNode` #99 + `fish-lsp info` change

### DIFF
--- a/docs/MAN_FILE.md
+++ b/docs/MAN_FILE.md
@@ -64,7 +64,7 @@ show the build info of fish-lsp
   `--capabilities`            show the lsp capabilities  
   `--man-file`                show the man file path  
   `--log-file`                show the log file path  
-  `--more`                    show the build time of the fish-lsp executable  
+  `--extra`                   show all info, including capabilities, paths, and version  
   `--time-startup`            time the startup of the fish-lsp executable  
   `--health-check`            run diagnostics and report health status  
 

--- a/docs/man/fish-lsp.1
+++ b/docs/man/fish-lsp.1
@@ -87,7 +87,7 @@ show the build info of fish\-lsp
 .br
 \fB\-\-log\-file\fP                show the log file path
 .br
-\fB\-\-more\fP                    show the build time of the fish\-lsp executable
+\fB\-\-extra\fP                   show all info, including capabilities, paths, and version
 .br
 \fB\-\-time\-startup\fP            time the startup of the fish\-lsp executable
 .br

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -158,7 +158,7 @@ commandBin.command('info')
   .option('--man-file', 'show the man file path')
   .option('--logs-file', 'show the logs file path')
   .option('--log-file', 'show the log file path')
-  .option('--more', 'show the build time of the fish-lsp executable')
+  .option('--extra', 'show all info, including capabilities, paths, and version')
   .option('--time-startup', 'time the startup of the fish-lsp executable')
   .option('--health-check', 'run diagnostics and report health status')
   .option('--check-health', 'run diagnostics and report health status')
@@ -213,9 +213,11 @@ commandBin.command('info')
     logger.logToStdout(`Binary File: ${PathObj.bin}`);
     logger.logToStdout(`Man File: ${PathObj.manFile}`);
     logger.logToStdout(`Log File: ${config.fish_lsp_log_file}`);
-    logger.logToStdout('_'.repeat(parseInt(process.env.COLUMNS || '80')));
-    logger.logToStdout('CAPABILITIES:');
-    logger.logToStdout(capabilities);
+    if (args.extra || args.capabilities) {
+      logger.logToStdout('_'.repeat(parseInt(process.env.COLUMNS || '80')));
+      logger.logToStdout('CAPABILITIES:');
+      logger.logToStdout(capabilities);
+    }
     process.exit(0);
   });
 

--- a/src/utils/get-lsp-completions.ts
+++ b/src/utils/get-lsp-completions.ts
@@ -275,7 +275,7 @@ complete -c fish-lsp -n '__fish_seen_subcommand_from info; and not __fish_contai
 complete -c fish-lsp -n '__fish_seen_subcommand_from info; and not __fish_contains_opt capabilities'  -l capabilities   -d 'show the lsp capabilities implemented' 
 complete -c fish-lsp -n '__fish_seen_subcommand_from info; and not __fish_contains_opt man-file'      -l man-file       -d 'show man file path' 
 complete -c fish-lsp -n '__fish_seen_subcommand_from info; and not __fish_contains_opt log-file'      -l log-file       -d 'show log file path' 
-complete -c fish-lsp -n '__fish_seen_subcommand_from info; and not __fish_contains_opt more'          -l more           -d 'show more info' 
+complete -c fish-lsp -n '__fish_seen_subcommand_from info; and not __fish_contains_opt extra'         -l extra          -d 'show all info, including capabilities, paths, and version' 
 complete -c fish-lsp -n '__fish_seen_subcommand_from info; and not __fish_contains_opt time-startup'  -l time-startup   -d 'show startup timing info'
 complete -c fish-lsp -n '__fish_seen_subcommand_from info; and not __fish_contains_opt check-health'  -l check-health   -d 'show the server health'
 `;


### PR DESCRIPTION
- Prior to this PR `FishSymbol` for [`src/parsing/set.ts`](https://github.com/ndonfris/fish-lsp/blob/ef9217b6dfd18de4baae760ad4a7f1eec3947059/src/parsing/set.ts#L114), the `FishSymbol.scope.scopeNode` was set incorrectly when a set definition used the `--function` modifier to change the definitions scope. Now, symbol definitions using `set --function` syntax, are correctly scope

- The command `fish-lsp info` no longer includes capabilities in its output. To include the capabilities (like the prior usage of this command showed), please use the new switch `--extra`:

   ```fish
   fish-lsp info --extra
   ```

- Documentation was updated for both of these changes 