### PR TITLE
feat(nix:scripts/build-time): allow builds to skip embedding build-ti…

### DIFF
--- a/scripts/build-time
+++ b/scripts/build-time
@@ -84,8 +84,28 @@ const verbose = (...args) => flags.verbose && console.log(...args);
 const exit = (code = 0) => process.exit(flags.forceSuccess ? 0 : code);
 
 try {
-    const now = new Date();
-    const timestamp = new Date().toLocaleString(undefined, {dateStyle: 'short', timeStyle: 'medium'});
+    // Check for reproducible build mode (for Nix and other package managers)
+    // Use SOURCE_DATE_EPOCH if provided for deterministic builds
+    let now;
+    let usingSourceDateEpoch = false;
+
+    if (process.env.SOURCE_DATE_EPOCH) {
+        // Nix and other reproducible build systems set this to make builds deterministic
+        // This allows the build-time.json to exist but with a fixed timestamp
+        now = new Date(parseInt(process.env.SOURCE_DATE_EPOCH) * 1000);
+        usingSourceDateEpoch = true;
+        verbose('Using SOURCE_DATE_EPOCH for deterministic build:'.green(), process.env.SOURCE_DATE_EPOCH);
+    } else if (process.env.REPRODUCIBLE_BUILD === '1') {
+        // Skip build-time.json creation entirely (alternative approach)
+        log('Skipping build-time.json creation for reproducible build'.yellow());
+        verbose('REPRODUCIBLE_BUILD=1 detected, skipping...'.dim());
+        exit(0);
+    } else {
+        // Normal build - use current time
+        now = new Date();
+    }
+
+    const timestamp = now.toLocaleString(undefined, {dateStyle: 'short', timeStyle: 'medium'});
     const buildTimeData = {
         date: now.toDateString(),
         timestamp,
@@ -131,7 +151,11 @@ try {
     }
 
     log('✓  created JSON at:'.bgGreen().black().bold(), path.basename(jsonFilePath).cyan().dim());
-    log('✓  with timestamp: '.bgGreen().black().bold(), timestamp.blue().dim());
+    if (usingSourceDateEpoch) {
+        log('✓  with timestamp: '.bgGreen().black().bold(), timestamp.blue().dim(), '(from SOURCE_DATE_EPOCH)'.gray().dim());
+    } else {
+        log('✓  with timestamp: '.bgGreen().black().bold(), timestamp.blue().dim());
+    }
 
 } catch (error) {
     error("ERROR:".bgRed().white().bold(), "Script execution failed.".red());

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -284,7 +284,7 @@ commandBin.command('info')
       }
       // handle `[--man-file | --log-file] (--show)?`
       if (args.manFile || args.logFile || args.logsFile) {
-        exitCode = CommanderSubcommand.info.handleFileArgs(args);
+        exitCode = CommanderSubcommand.info.handleFileArgs(args) ?? 0;
         shouldExit = true;
       }
       // handle `--virtual-fs`


### PR DESCRIPTION

* server doesn't require out/build-time.json to be included in embedded binary
* server uses `fs.stat()` to resolve last modification made to server for build-time
* using `fs.stat()` might be able to entirely resolve the build-time info that server provides to all of its different usage targets instead of needing the json version at all

potential fix to [`nixpkgs/fish-lsp#446470`](https://github.com/NixOS/nixpkgs/pull/446470#issuecomment-3445516730)