### PR TITLE
fix(semantic-tokens): use predefined modifier for builtins

### DIFF
--- a/src/semantic-tokens.ts
+++ b/src/semantic-tokens.ts
@@ -183,7 +183,7 @@ const nodeToTokenHandler: NodeToToken[] = [
       const openBracket = firstChild.firstChild;
       if (openBracket && openBracket.type === '[') {
         ctx.tokens.push(
-          SemanticToken.fromNode(openBracket, FishSemanticTokens.types.function, calculateModifiersMask('builtin')),
+          SemanticToken.fromNode(openBracket, FishSemanticTokens.types.function, calculateModifiersMask('defaultLibrary')),
         );
       }
     }
@@ -194,7 +194,7 @@ const nodeToTokenHandler: NodeToToken[] = [
       const closeBracket = lastChild.firstChild;
       if (closeBracket && closeBracket.type === ']') {
         ctx.tokens.push(
-          SemanticToken.fromNode(closeBracket, FishSemanticTokens.types.function, calculateModifiersMask('builtin')),
+          SemanticToken.fromNode(closeBracket, FishSemanticTokens.types.function, calculateModifiersMask('defaultLibrary')),
         );
       }
     }
@@ -212,6 +212,10 @@ const nodeToTokenHandler: NodeToToken[] = [
 
   // Builtin functions: `echo`, `set`, `path`, `source`, etc.
   // These are commands from `builtin -n` but not structural keywords
+  //
+  // As of PR #133, builtin functions are now treated exactly the same
+  // as defaultLibrary functions which include shared function definitions
+  // like: `__fish_use_subcommand` or other `$__fish_data_dir/functions/*.fish` files
   [isBuiltinFunction, (n, ctx) => {
     const cmd = n.firstNamedChild;
     if (!cmd) return;

--- a/src/utils/semantics.ts
+++ b/src/utils/semantics.ts
@@ -114,8 +114,7 @@ export const SemanticTokenModifiers = {
   ['global']: 'global',                  // Global scope variables/functions
   ['universal']: 'universal',            // Universal scope variables
   ['export']: 'export',                  // Exported variables
-  ['defaultLibrary']: 'defaultLibrary',  // Fish-shipped functions
-  ['builtin']: 'builtin',                // Built-in commands
+  ['defaultLibrary']: 'defaultLibrary',  // Fish-shipped functions (now builtins and other shipped functions are both 'defaultLibrary')
 } as const;
 export type SemanticTokenModifier = (typeof SemanticTokenModifiers)[keyof typeof SemanticTokenModifiers];
 
@@ -148,11 +147,6 @@ export namespace FishSemanticTokens {
 
 }
 
-// export const FISH_SEMANTIC_TOKENS_LEGEND: SemanticTokensLegend = {
-//   tokenTypes: SemanticTokenTypes ? Object.values(SemanticTokenTypes) : [],
-//   tokenModifiers: SemanticTokenModifiers ? Object.values(SemanticTokenModifiers) : [],
-// } as SemanticTokensLegend;
-
 export function getTokenTypeIndex(tokenType: string): number {
   return FishSemanticTokens.types[tokenType as SemanticTokenType] || 0;
 }
@@ -171,13 +165,7 @@ export function calculateModifiersMask(...modifiers: string[]): number {
   }
   return mask;
 }
-//
-// export function hasModifier(mask: number, modifier: string): boolean {
-//   const index = getModifierIndex(modifier);
-//   if (index === -1) return false;
-//   return (mask & 1 << index) !== 0;
-// }
-//
+
 export function getModifiersFromMask(mask: number): string[] {
   const modifiers: string[] = [];
   for (let i = 0; i < Object.values(FishSemanticTokens.mods).length; i++) {
@@ -188,23 +176,6 @@ export function getModifiersFromMask(mask: number): string[] {
   }
   return modifiers;
 }
-
-// export function getCaptureToTokenMapping(): Record<string, { tokenType: string; index: number; }> {
-//   const captureNames = extractCaptureNames(highlights);
-//   const mapping: Record<string, { tokenType: string; index: number; }> = {};
-//
-//   for (const captureName of captureNames) {
-//     const tokenType = mapCaptureToTokenType(captureName);
-//     const index = getTokenTypeIndex(tokenType);
-//
-//     mapping[captureName] = {
-//       tokenType,
-//       index,
-//     };
-//   }
-//
-//   return mapping;
-// }
 
 export function nodeIntersectsRange(node: SyntaxNode, range: Range): boolean {
   const nodeStart = Position.create(node.startPosition.row, node.startPosition.column);
@@ -403,7 +374,7 @@ export function getCommandModifierInfo(commandNode: SyntaxNode, documentUri?: st
 
   // Check if it's a builtin command
   if (isBuiltin(commandName)) {
-    return { modifiers: calculateModifiersMask('builtin'), isDefinedInDocument: false };
+    return { modifiers: calculateModifiersMask('defaultLibrary'), isDefinedInDocument: false };
   }
 
   const allCommands = PrebuiltDocumentationMap.getByType('command');

--- a/tests/semantic-tokens.test.ts
+++ b/tests/semantic-tokens.test.ts
@@ -1,12 +1,6 @@
-// import { SyntaxNode } from 'web-tree-sitter';
 import { analyzer, Analyzer } from '../src/analyze';
 import { LspDocument } from '../src/document';
-// import {
-//   FISH_SEMANTIC_TOKENS_LEGEND,
-//   getModifiersFromMask,
-//   getTokenTypeIndex,
-// } from '../src/utils/semantics';
-import { config, Config } from '../src/config';
+import { config } from '../src/config';
 import { TestWorkspace, TestFile } from './test-workspace-utils';
 import { Range } from 'vscode-languageserver';
 import { setupProcessEnvExecFile } from '../src/utils/process-env';
@@ -18,8 +12,6 @@ import {
   printTokens,
   type DecodedToken,
 } from './semantic-tokens-helpers';
-import FishServer from '../src/server';
-import { connection, startServer } from '../src/utils/startup';
 import { getSemanticTokensSimplest, semanticTokenHandler } from '../src/semantic-tokens';
 import { getRange } from '../src/utils/tree-sitter';
 import { PrebuiltDocumentationMap } from '../src/utils/snippets';
@@ -28,9 +20,9 @@ import { FishCompletionItemKind } from '../src/utils/completion/types';
 import { logger } from '../src/logger';
 import { pathToUri } from '../src/utils/translation';
 import { existsSync } from 'fs';
-import { createFakeLspDocument, FakeLspDocument, setLogger } from './helpers';
+import { createFakeLspDocument, FakeLspDocument } from './helpers';
 import { join } from 'path';
-// setLogger();
+
 logger.setSilent(true);
 
 /**
@@ -203,9 +195,6 @@ complete -c deployctl -l retries -d 'Retry count'
     await Analyzer.initialize();
     await setupProcessEnvExecFile();
     config.fish_lsp_disabled_handlers = ['diagnostic'];
-    // startServer();
-    // const opts = Config.getResultCapabilities();
-    // await FishServer.create(connection, opts as any);
 
     basic_doc = testWorkspace.getDocument('basic.fish')!;
     variables_doc = testWorkspace.getDocument('variables.fish')!;
@@ -932,7 +921,8 @@ export LANG=en_US.UTF-8`;
       expect(funcTokens.length).toBeGreaterThan(0);
     });
 
-    it('should differentiate between builtin commands and user functions', () => {
+    // now just defaultLibrary modifier for builtins
+    it('should differentiate between builtin commands (defaultModifier) and user functions', () => {
       const analyzed = analyzer.cache.getDocument(commands_doc.uri)?.ensureParsed();
       const result = getSemanticTokensSimplest(analyzed!, getRange(analyzed!.root));
       const tokens = decodeSemanticTokens(result, commands_doc.getText());


### PR DESCRIPTION
Use the [predefined](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#semanticTokenModifiers) `defaultLibrary` semantic token modifier instead of the custom `builtin` one we use for builtins. We don't use `defaultLibrary` for anything else, so it's better not to use custom modifiers if we can.
