### PR TITLE
fix: `argparse $options` doesn't define `_flag_$options` (issue #136)

### DIFF
--- a/src/code-actions/argparse-completions.ts
+++ b/src/code-actions/argparse-completions.ts
@@ -1,19 +1,23 @@
 import { SyntaxNode } from 'web-tree-sitter';
-import { findParentFunction, isCommandName, isCommandWithName, isEndStdinCharacter, isFunctionDefinition, isMatchingOption, isOption, isString } from '../utils/node-types';
+import { findParentFunction, isCommandWithName, isFunctionDefinition, isString } from '../utils/node-types';
 import { getChildNodes, getRange } from '../utils/tree-sitter';
 import { LspDocument } from '../document';
 import { ChangeAnnotation, CodeAction, CodeActionKind, TextDocumentEdit, TextEdit, VersionedTextDocumentIdentifier, WorkspaceEdit } from 'vscode-languageserver';
 import { extractFunctionWithArgparseToCompletionsFile } from './refactors';
 import { uriToReadablePath } from '../utils/translation';
 import { logger } from '../logger';
-import { Option } from '../parsing/options';
+import { findArgparseDefinitionNames } from '../parsing/argparse';
 
 export type CompleteFlag = {
   shortOption?: string;
   longOption: string;
 };
 
-function parseArgparseFlag(text: string): CompleteFlag {
+// export function parseArgparseFlag(text: string): CompleteFlag {
+function parseArgparseFlag(node: SyntaxNode): CompleteFlag {
+  let text = node.text;
+  if (isString(node)) text = text.slice(1, -1);
+
   // Remove any equals and following text
   const beforeEquals = text.split('=')[0] as string;
 
@@ -32,51 +36,12 @@ function parseArgparseFlag(text: string): CompleteFlag {
   };
 }
 
-function isSkipablePreviousOption(node: SyntaxNode): boolean {
-  // don't skip previous nodes when the previous node is of the form:
-  // ```fish
-  // argparse -N=1 --max-args=2
-  // ```
-  if (node.text.includes('=')) return false;
-  return isMatchingOption(node, Option.create('-N', '--min-args')) ||
-    isMatchingOption(node, Option.create('-n', '--name')) ||
-    isMatchingOption(node, Option.create('-x', '--exclusive')) ||
-    isMatchingOption(node, Option.create('-X', '--max-args'));
-}
-
 export function findFlagsToComplete(node: SyntaxNode): CompleteFlag[] {
   if (!isCommandWithName(node, 'argparse')) return [];
-
   const flags: CompleteFlag[] = [];
-
-  for (const child of getChildNodes(node)) {
-    // Stop at -- argument separator
-    if (isEndStdinCharacter(child)) break;
-
-    // skip `argparse` command name
-    if (isCommandName(child)) continue;
-
-    // Skip command name and actual options (like --ignore-unknown)
-    if (isOption(child)) continue;
-
-    // skip previous options that are not flags
-    const prev = child.previousSibling;
-    if (prev && isOption(prev) && isSkipablePreviousOption(prev)) continue;
-
-    // Handle quoted strings
-    if (isString(child)) {
-      // Remove surrounding quotes
-      const text = child.text.slice(1, -1);
-      flags.push(parseArgparseFlag(text));
-      continue;
-    }
-
-    // Handle unquoted option strings
-    if (child.type === 'word' && !child.text.startsWith('-')) {
-      flags.push(parseArgparseFlag(child.text));
-    }
+  for (const n of findArgparseDefinitionNames(node)) {
+    flags.push(parseArgparseFlag(n));
   }
-
   return flags;
 }
 

--- a/src/parsing/argparse.ts
+++ b/src/parsing/argparse.ts
@@ -1,12 +1,12 @@
+import path, { dirname } from 'path';
 import { SyntaxNode } from 'web-tree-sitter';
-import { isCommandWithName, isEndStdinCharacter, isString, isEscapeSequence, isVariableExpansion, isCommand, isInvalidVariableName, findParentWithFallback, isFunctionDefinition } from '../utils/node-types';
-import { findOptions, isMatchingOption, Option } from './options';
 import { FishSymbol } from './symbol';
 import { LspDocument } from '../document';
-import { DefinitionScope, ScopeTag } from '../utils/definition-scope';
-import { getRange } from '../utils/tree-sitter';
 import { analyzer } from '../analyze';
-import path, { dirname } from 'path';
+import { getRange } from '../utils/tree-sitter';
+import { DefinitionScope, ScopeTag } from '../utils/definition-scope';
+import { findOptions, isMatchingOption, Option } from './options';
+import { isCommandWithName, isEndStdinCharacter, isString, isEscapeSequence, isVariableExpansion, isCommand, isInvalidVariableName, findParentWithFallback, isFunctionDefinition, isOption } from '../utils/node-types';
 import { SyncFileHelper } from '../utils/file-operations';
 import { pathToUri, uriToPath } from '../utils/translation';
 import { workspaceManager } from '../utils/workspace-manager';
@@ -17,10 +17,21 @@ export const ArgparseOptions = [
   Option.create('-x', '--exclusive').withValue(),
   Option.create('-N', '--min-args').withValue(),
   Option.create('-X', '--max-args').withValue(),
+  Option.create('-U', '--move-unknown'),
+  Option.create('-S', '--strict-longopts'),
+  Option.long('--unknown-arguments').withValue(),
   Option.create('-i', '--ignore-unknown'),
   Option.create('-s', '--stop-nonopt'),
   Option.create('-h', '--help'),
 ];
+
+const ArgparseOptsWithValues = ArgparseOptions.filter(opt =>
+  opt.equalsRawOption('-n', '--name') ||
+  opt.equalsRawOption('-x', '--exclusive') ||
+  opt.equalsRawOption('-N', '--min-args') ||
+  opt.equalsRawOption('-X', '--max-args') ||
+  opt.equalsRawOption('--unknown-arguments'),
+);
 
 const isBefore = (a: SyntaxNode, b: SyntaxNode) => a.startIndex < b.startIndex;
 
@@ -34,15 +45,67 @@ export function findArgparseOptions(node: SyntaxNode) {
   return findOptions(nodes, ArgparseOptions);
 }
 
+/**
+ * Utility to ensure that args for `argparse` option variable definitions exclude
+ * argparse's optspec nodes, which can be in the form of:
+ *   • `-n foo`, `--name foo`
+ *   • `-x g,U`, `--exclusive=g,U`
+ *   • `--ignore-unknown`, `--stop-nonopt`
+ *   • `--unknown-arguments=KIND`
+ *   • `-N 1`, `--min-args=1` , `--max-args=2` , '-X 2'
+ *
+ * Backtrack using the current node, to check if the previous node is an `argparse` switch
+ * that would inidicate the current node is a value for that switch, and
+ * should not be included as an `argparse` definition name.
+ *
+ * @example
+ * ```fish
+ * argparse -n=foo -x g,U --ignore-unknown --stop-nonopt h/help 'n/name=?' 'x/exclusive' -- $argv
+ * #        ^^^^^^ ^^     ^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^ skipped via (check 1)
+ * #                  ^^^                               skipped via (check 2)
+ * ```
+ */
+function isArgparseOptionSpecifier(node: SyntaxNode) {
+  // Check 1
+  if (isOption(node)) return true;
+
+  // Check 2
+  const previousNode = node.previousSibling;
+  if (!previousNode) return false;
+
+  // we return false here to indicate that we should not skip this node
+  // because the value for the previous node was provided using `--flag=value` syntax
+  if (previousNode.text.includes('=')) return false;
+
+  // don't skip previous nodes when the previous node is of the form:
+  // ```fish
+  // argparse -N 1 --max-args 2
+  // #           ^            ^
+  // #           Both of these nodes are excluded
+  // ```
+  return ArgparseOptsWithValues.some((option) => isMatchingOption(previousNode, option));
+  // return isMatchingOption(previousNode, Option.create('-n', '--name')) ||
+  //   isMatchingOption(previousNode, Option.create('-x', '--exclusive')) ||
+  //   isMatchingOption(previousNode, Option.create('-N', '--min-args')) ||
+  //   isMatchingOption(previousNode, Option.create('-X', '--max-args')) ||
+  //   isMatchingOption(previousNode, Option.long('--unknown-arguments'))
+}
+
 function isInvalidArgparseName(node: SyntaxNode) {
   if (isEscapeSequence(node) || isCommand(node) || isInvalidVariableName(node)) return true;
-  if (isVariableExpansion(node) && node.type === 'variable_name') return true;
+  if (isArgparseOptionSpecifier(node)) return true;
+  if (isVariableExpansion(node) || node.type === 'variable_name') return true;
+  // fixup the text, so we ignore '/" characters surrounding the flag names,
   let text = node.text.trim();
   if (isString(node)) {
     text = text.slice(1, -1);
-    text = text.slice(0, text.indexOf('=') || -1);
   }
-  if (text.includes('(')) return true; // skip function calls
+  // ignore anything after an `=` character since that would not be part of the variable name
+  text = text.slice(0, text.indexOf('=') || -1);
+  // incase parser missed one of these cases, we do a final check to see if the text includes
+  // any characters that would be invalid for an argparse variable definition
+  // (e.g., command substitutions, variable expansions)
+  if (text.includes('(') || text.includes('$')) return true;
   return false;
 }
 

--- a/tests/fish-symbol.test.ts
+++ b/tests/fish-symbol.test.ts
@@ -8,6 +8,9 @@ import { flattenNested } from '../src/utils/flatten';
 import * as Parser from 'web-tree-sitter';
 import { SyntaxNode } from 'web-tree-sitter';
 import { config } from '../src/config';
+import { createArgparseCompletionsCodeAction, findFlagsToComplete } from '../src/code-actions/argparse-completions';
+import { isCommand } from '../src/utils/node-types';
+import { TextDocumentEdit } from 'vscode-languageserver';
 
 let parser: Parser;
 let testBuilder: ReturnType<typeof setupTestCallback>;
@@ -986,12 +989,12 @@ describe('`./src/parsing/**.ts` tests', () => {
           'set -l FOO foo',
           '__foo $FOO',
         );
-        const { flatSymbols, symbols } = getAllTypesOfNestedArrays(doc, root);
+        const { flatSymbols } = getAllTypesOfNestedArrays(doc, root);
         const lastSymbols = filterLastPerScopeSymbol(flatSymbols);
-        console.log({
-          all: flatSymbols.map(s => s.name),
-          last: lastSymbols.map(s => s.name),
-        });
+        // console.log({
+        //   all: flatSymbols.map(s => s.name),
+        //   last: lastSymbols.map(s => s.name),
+        // });
         expect(lastSymbols).toHaveLength(5);
         expect(lastSymbols.map(s => s.name)).toEqual(['argv', '__foo', 'FOO', 'argv', 'FOO']);
       });
@@ -1094,6 +1097,152 @@ describe('`./src/parsing/**.ts` tests', () => {
       // console.log(JSON.stringify(completions, null, 2));
       expect(firstCompletions).toHaveLength(1);
       expect(secondCompletions).toHaveLength(1);
+    });
+
+    // test for [#136](https://github.com/ndonfris/fish-lsp/issues/136)
+    //
+    it('`argparse variable expansion in opt` (`argparse $opts -- $argv` prevent `_flag_$opts`)', () => {
+      const { doc, root } = testBuilder('functions/foo.fish',
+        'function foo',
+        '  set -l options \'v/verbose\' ',
+        '  argparse --stop-nonopt $options f/first s/second \'t/third=!_validate_int\' -- $argv',
+        '  or return',
+        '  echo $_flag_first',
+        '  echo $_flag_second',
+        '  echo $_flag_third',
+        'end',
+      );
+      const { flatSymbols /** nodes */ } = getAllTypesOfNestedArrays(doc, root);
+      const optionsVariable = flatSymbols.find(s => s.name === 'options' && s.fishKind === 'ARGPARSE');
+
+      /**
+       * optionsVariable is expected to be undefined since we don't treat variable
+       * expansion in `argparse` as defining the variable.
+       */
+      expect(optionsVariable).toBeUndefined();
+      const mappedFlags = flatSymbols.map(s => [s.name, s.fishKind]);
+      // mappedFlags.forEach((item) => { console.log(item); });
+
+      /**
+       * make sure that the flags defined by `argparse` are still correctly identified
+       * as `ARGPARSE` kind even if variable expansion is used in the `argparse` command.
+       */
+      expect(mappedFlags).toEqual([
+        ['foo', 'FUNCTION'],
+        ['argv', 'FUNCTION_VARIABLE'],
+        ['options', 'SET'],
+        // ['options', 'ARGPARSE'], /** Doesn't exist which is expected since we don't treat variable expansion in `argparse` as defining the variable. */
+        ['_flag_f', 'ARGPARSE'],
+        ['_flag_first', 'ARGPARSE'],
+        ['_flag_s', 'ARGPARSE'],
+        ['_flag_second', 'ARGPARSE'],
+        ['_flag_t', 'ARGPARSE'],
+        ['_flag_third', 'ARGPARSE'],
+      ]);
+    });
+  });
+  describe('extra argparse tests', () => {
+    it('`argparse` with variable expansion in options and flags', () => {
+      const { doc, root } = testBuilder('functions/foo.fish',
+        'function foo',
+        '  set -l options \'v/verbose\' ',
+        '  argparse --stop-nonopt $options f/first s/second \'t/third=!_validate_int\' -- $argv',
+        '  or return',
+        'end',
+      );
+      const { flatSymbols } = getAllTypesOfNestedArrays(doc, root);
+      const optionsVariable = flatSymbols.find(s => s.name === 'options' && s.fishKind === 'ARGPARSE');
+      const argparseFlags = flatSymbols.filter(s => s.fishKind === 'ARGPARSE');
+      expect(optionsVariable).toBeUndefined();
+      expect(argparseFlags).toHaveLength(6);
+      const flagNames = argparseFlags.map(s => s.name);
+      expect(flagNames).toEqual(['_flag_f', '_flag_first', '_flag_s', '_flag_second', '_flag_t', '_flag_third']);
+      const allArgparseFlags = argparseFlags.map(s => ({ name: s.name, kind: s.fishKind }));
+      expect(allArgparseFlags).toEqual([
+        { name: '_flag_f', kind: 'ARGPARSE' },
+        { name: '_flag_first', kind: 'ARGPARSE' },
+        { name: '_flag_s', kind: 'ARGPARSE' },
+        { name: '_flag_second', kind: 'ARGPARSE' },
+        { name: '_flag_t', kind: 'ARGPARSE' },
+        { name: '_flag_third', kind: 'ARGPARSE' },
+      ]);
+    });
+
+    it('`argparse` with variable expansion inside string', () => {
+      const { doc, root } = testBuilder('conf.d/foo.fish',
+        'function foo',
+        '  set -l options \'v/verbose\' ',
+        '  set -l normal_opts \'h/help\' \'d/debug\'',
+        '  set -l validate_opts --min 1 --max 10',
+        '  argparse --stop-nonopt "$options" \'$normal_opts\' f/first s/second \'t/third=!_validate_int $validate_opts\' -- $argv',
+        '  or return',
+        'end',
+      );
+      const { flatSymbols, nodes } = getAllTypesOfNestedArrays(doc, root);
+      const argparseNode = nodes.find(n => isCommand(n) && n.firstNamedChild!.text === 'argparse')!;
+      const argparseFlags = flatSymbols.filter(s => s.fishKind === 'ARGPARSE');
+      const allArgparseFlags = argparseFlags.map(s => ({ name: s.name, kind: s.fishKind }));
+      // console.log({ allArgparseFlags });
+      expect(allArgparseFlags).toEqual([
+        { name: '_flag_f', kind: 'ARGPARSE' },
+        { name: '_flag_first', kind: 'ARGPARSE' },
+        { name: '_flag_s', kind: 'ARGPARSE' },
+        { name: '_flag_second', kind: 'ARGPARSE' },
+        { name: '_flag_t', kind: 'ARGPARSE' },
+        { name: '_flag_third', kind: 'ARGPARSE' },
+      ]);
+
+      const ca = createArgparseCompletionsCodeAction(argparseNode, doc);
+      expect(ca).toBeDefined();
+      // console.log(JSON.stringify({ ca }, null, 2));
+      const edit = ca!.edit!.documentChanges![0]! as TextDocumentEdit;
+      const newText = edit.edits.map(e => e.newText).join('');
+      expect(newText).toBeDefined();
+      expect(newText).toContain('complete -c foo -s f -l first');
+      expect(newText).toContain('complete -c foo -s s -l second');
+      expect(newText).toContain('complete -c foo -s t -l third');
+    });
+
+    it('`argparse` with variable expansion in options and flags in conf.d file', () => {
+      const { doc, root } = testBuilder('conf.d/foo.fish',
+        'function __foo_parse',
+        '  set -l options \'v/verbose\' ',
+        '  set -l validate_opts --min 1 --max 10',
+        '  argparse --name=__foo_parse --stop-nonopt --min-args 1 --max-args=2 $options f/first s/second \'t/third=!_validate_int $validate_opts\' \'fourth=\' -- $argv',
+        '  or return',
+        'end',
+      );
+      const { flatSymbols, nodes } = getAllTypesOfNestedArrays(doc, root);
+      const argparseNode = nodes.find(n => isCommand(n) && n.firstNamedChild!.text === 'argparse')!;
+      const expectedFlags = findFlagsToComplete(argparseNode);
+      expect(expectedFlags).toEqual([
+        { shortOption: 'f', longOption: 'first' },
+        { shortOption: 's', longOption: 'second' },
+        { shortOption: 't', longOption: 'third' },
+        { longOption: 'fourth' },
+      ]);
+      const optionsVariable = flatSymbols.find(s => s.name === 'options' && s.fishKind === 'ARGPARSE');
+      const argparseFlags = flatSymbols.filter(s => s.fishKind === 'ARGPARSE');
+      expect(optionsVariable).toBeUndefined();
+      expect(argparseFlags).toHaveLength(7);
+      expect(argparseFlags.map(s => s.name)).toEqual([
+        '_flag_f',
+        '_flag_first',
+        '_flag_s',
+        '_flag_second',
+        '_flag_t',
+        '_flag_third',
+        '_flag_fourth',
+      ]);
+      const codeAction = createArgparseCompletionsCodeAction(argparseNode, doc)!;
+      expect(codeAction).toBeDefined();
+      const docEdits = codeAction.edit!.documentChanges! as TextDocumentEdit[];
+      const textEdits = docEdits.map(e => e.edits).flat().map(e => e.newText).join('');
+      expect(textEdits).toBeDefined();
+      expect(textEdits).toContain('complete -c __foo_parse -s f -l first');
+      expect(textEdits).toContain('complete -c __foo_parse -s s -l second');
+      expect(textEdits).toContain('complete -c __foo_parse -s t -l third');
+      expect(textEdits).toContain('complete -c __foo_parse -l fourth');
     });
   });
 });


### PR DESCRIPTION
- new tests for this issue
- ignores any argparse variable name where `$` is before `=`