### PR TITLE
fix: `set name -fxgU` doesn't display value that matches scope modifier

### DIFF
--- a/src/parsing/set.ts
+++ b/src/parsing/set.ts
@@ -77,7 +77,10 @@ export function findSetChildren(node: SyntaxNode) {
 }
 
 export function setModifierDetailDescriptor(node: SyntaxNode) {
-  const options = findOptions(node.childrenForFieldName('argument'), SetModifiers);
+  let children = node.childrenForFieldName('argument');
+  if (isSetDefinition(node)) children = findSetChildren(node);
+
+  const options = findOptions(children, SetModifiers);
   const exportedOption = options.found.find(o => o.option.equalsRawOption('-x', '--export') || o.option.equalsRawOption('-u', '--unexport'));
   const exportedStr = exportedOption ? exportedOption.option.isOption('-x', '--export') ? 'exported' : 'unexported' : '';
   const modifier = options.found.find(o => o.option.equalsRawOption('-U', '-g', '-f', '-l'));


### PR DESCRIPTION
* issue #142 notes scope issues, without out of order scope modifier flags in set definition (after variable name), this fixes the definitions so that set stops at first option that is now flag when looking for scope modifiers in command node's children

* example: `set var --function` is set to `locally scoped` in hover docs of `FishSymbol`, not `function scoped`