### PR TITLE
fix: double code block in completion docs

### DIFF
--- a/src/utils/completion/documentation.ts
+++ b/src/utils/completion/documentation.ts
@@ -4,7 +4,7 @@ import { execCmd, execCommandDocs } from '../exec';
 import { md } from '../markdown-builder';
 
 export async function getDocumentationResolver(item: FishCompletionItem): Promise<MarkupContent> {
-  let docString: string = ['```fish', item.documentation.toString(), '```'].join('\n');
+  let docString: string = item.documentation.toString();
   if (!item.local) {
     switch (item.fishKind) {
       case FishCompletionItemKind.ABBR:


### PR DESCRIPTION
Currently it seems like completion docs sometimes render inside a fish code block such as:

<pre>
```fish
(**function**) `__fish_echo`  
run the given command after the current commandline and redraw the prompt  
___  
autoloaded, globally scoped  
located in file: `$__fish_data_dir/functions/__fish_echo.fish`  
___  
```fish
function __fish_echo --description 'run the given command after the current commandline and redraw the prompt'
    set -l line (commandline --line)
    string >&2 repeat -N \n --count=(math (commandline | count) - $line + 1)
    echo -n \e\[J >&2
    $argv >&2
    string >&2 repeat -N \n --count=(math (count (fish_prompt)) - 1)
    string >&2 repeat -N \n --count=(math $line - 1)
    commandline -f repaint
end
```
```
</pre>

Which ends up rendering like this:

<img width="3640" height="1009" alt="image" src="https://github.com/user-attachments/assets/2ed99150-0197-410c-be63-153de7eabf29" />

From a quick look at the code, it doesn't seem like the outer block is really needed? Removing it gives the desired effect and I don't see any regression in the existing completion docs:

<img width="3681" height="992" alt="image" src="https://github.com/user-attachments/assets/e4bb3dff-6b07-451b-b549-e85b3218cdfd" />
