### PR TITLE
fix: `src/formatting.ts` changes for #159

### DIFF
--- a/scripts/esbuild/configs.ts
+++ b/scripts/esbuild/configs.ts
@@ -89,7 +89,6 @@ export const buildConfigs: Record<BuildConfigTarget, BuildConfig> = {
     // External dependencies - don't bundle these, npm will provide them
     external: [
       '@esdmr/tree-sitter-fish',
-      'chalk',
       'commander',
       'fast-glob',
       'fs-extra',

--- a/src/formatting.ts
+++ b/src/formatting.ts
@@ -1,40 +1,81 @@
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import { logger } from './logger';
 import { LspDocument } from './document';
 import { getEnabledIndentRanges } from './parsing/comments';
 
-export async function formatDocumentContent(content: string): Promise<string> {
-  return new Promise((resolve, _reject) => {
-    const process = exec('fish_indent', (error, stdout, stderr) => {
-      if (error) {
-        // reject(stderr);
-        logger.log('Formatting Error:', stderr);
-      } else {
-        resolve(stdout);
-      }
-    });
-    if (process.stdin) {
-      process.stdin.write(content);
-      process.stdin.end();
+// Cap fish_indent at a generous wall-clock so a hung child cannot hold the LSP
+// formatting request open past a client's request timeout (e.g. helix' ~20s).
+const FISH_INDENT_TIMEOUT_MS = 10_000;
+// fish_indent output is bounded by input size, but Node's default execFile
+// maxBuffer is 1 MiB which truncates large fish files. 50 MiB is well clear of
+// any realistic source while still capping pathological inputs.
+const FISH_INDENT_MAX_BUFFER = 50 * 1024 * 1024;
+
+function runFishIndent(content: string, args: string[] = []): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+
+    const resolveOnce = (value: string) => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    };
+
+    const rejectOnce = (error: Error) => {
+      if (settled) return;
+      settled = true;
+      logger.log('Formatting Error:', error.message);
+      reject(error);
+    };
+
+    const process = execFile(
+      'fish_indent',
+      args,
+      { timeout: FISH_INDENT_TIMEOUT_MS, maxBuffer: FISH_INDENT_MAX_BUFFER },
+      (error, stdout, stderr) => {
+        if (error) {
+          const err = error as NodeJS.ErrnoException & { killed?: boolean; signal?: string; };
+          let message: string;
+          if (err.killed && err.signal === 'SIGTERM') {
+            message = `fish_indent timed out after ${FISH_INDENT_TIMEOUT_MS}ms`;
+          } else if (err.code === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER') {
+            message = `fish_indent output exceeded ${FISH_INDENT_MAX_BUFFER} bytes`;
+          } else {
+            message = stderr.trim() || err.message;
+          }
+          rejectOnce(new Error(message));
+          return;
+        }
+
+        resolveOnce(stdout);
+      },
+    );
+
+    process.on('error', rejectOnce);
+
+    if (!process.stdin) {
+      rejectOnce(new Error('Unable to write to fish_indent stdin'));
+      process.kill();
+      return;
+    }
+
+    process.stdin.on('error', rejectOnce);
+
+    try {
+      process.stdin.end(content);
+    } catch (error) {
+      rejectOnce(error instanceof Error ? error : new Error(String(error)));
+      process.kill();
     }
   });
 }
 
+export async function formatDocumentContent(content: string): Promise<string> {
+  return runFishIndent(content);
+}
+
 export async function formatDocumentRangeContent(content: string): Promise<string> {
-  return new Promise((resolve, _reject) => {
-    const process = exec('fish_indent --only-indent --only-unindent', (error, stdout, stderr) => {
-      if (error) {
-        // reject(stderr);
-        logger.log('Formatting Error:', stderr);
-      } else {
-        resolve(stdout);
-      }
-    });
-    if (process.stdin) {
-      process.stdin.write(content);
-      process.stdin.end();
-    }
-  });
+  return runFishIndent(content, ['--only-indent', '--only-unindent']);
 }
 
 interface OriginalRange {

--- a/tests/formatting-child-process.test.ts
+++ b/tests/formatting-child-process.test.ts
@@ -1,0 +1,184 @@
+import { EventEmitter } from 'events';
+import { Writable } from 'stream';
+
+type ExecFileCallback = (error: Error | null, stdout: string, stderr: string) => void;
+type ExecFileOptions = { timeout?: number; maxBuffer?: number; };
+type ExecFileMock = (cmd: string, args: string[], options: ExecFileOptions, callback: ExecFileCallback) => unknown;
+
+function createMockProcess(stdin: Writable | null) {
+  const childProcess = new EventEmitter() as EventEmitter & {
+    stdin: Writable | null;
+    kill: ReturnType<typeof vi.fn>;
+  };
+
+  childProcess.stdin = stdin;
+  childProcess.kill = vi.fn();
+
+  return childProcess;
+}
+
+function mockFormattingDependencies() {
+  vi.doMock('../src/logger', () => ({
+    logger: {
+      log: vi.fn(),
+    },
+  }));
+  vi.doMock('../src/parsing/comments', () => ({
+    getEnabledIndentRanges: vi.fn(),
+  }));
+}
+
+describe('formatting child process failures', () => {
+  afterEach(() => {
+    vi.doUnmock('child_process');
+    vi.doUnmock('../src/logger');
+    vi.doUnmock('../src/parsing/comments');
+    vi.resetModules();
+  });
+
+  it('rejects when fish_indent closes stdin before content is written', async () => {
+    vi.resetModules();
+    mockFormattingDependencies();
+
+    const execFile: ExecFileMock = vi.fn((_cmd, _args, _options, _callback) => {
+      const stdin = new Writable({
+        write(_chunk, _encoding, callback) {
+          const error = new Error('write EPIPE') as NodeJS.ErrnoException;
+          error.code = 'EPIPE';
+          callback(error);
+        },
+      });
+
+      return createMockProcess(stdin);
+    });
+
+    vi.doMock('child_process', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('child_process')>();
+      return { ...actual, execFile };
+    });
+
+    const { formatDocumentContent } = await import('../src/formatting');
+
+    await expect(formatDocumentContent('echo test')).rejects.toThrow('write EPIPE');
+  });
+
+  it('rejects when fish_indent exits with an error', async () => {
+    vi.resetModules();
+    mockFormattingDependencies();
+
+    const execFile: ExecFileMock = vi.fn((_cmd, _args, _options, callback) => {
+      const stdin = new Writable({
+        write(_chunk, _encoding, writeComplete) {
+          writeComplete();
+        },
+      });
+      const childProcess = createMockProcess(stdin);
+
+      setImmediate(() => callback(new Error('fish_indent failed'), '', 'invalid fish syntax'));
+
+      return childProcess;
+    });
+
+    vi.doMock('child_process', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('child_process')>();
+      return { ...actual, execFile };
+    });
+
+    const { formatDocumentContent } = await import('../src/formatting');
+
+    await expect(formatDocumentContent('if')).rejects.toThrow('invalid fish syntax');
+  });
+
+  it('passes a timeout and maxBuffer to execFile so a hung child cannot stall the LSP', async () => {
+    vi.resetModules();
+    mockFormattingDependencies();
+
+    const seenOptions: ExecFileOptions[] = [];
+    const execFile: ExecFileMock = vi.fn((_cmd, _args, options, callback) => {
+      seenOptions.push(options);
+      const stdin = new Writable({
+        write(_chunk, _encoding, writeComplete) {
+          writeComplete();
+        },
+      });
+      const childProcess = createMockProcess(stdin);
+      setImmediate(() => callback(null, 'echo ok\n', ''));
+      return childProcess;
+    });
+
+    vi.doMock('child_process', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('child_process')>();
+      return { ...actual, execFile };
+    });
+
+    const { formatDocumentContent } = await import('../src/formatting');
+    await formatDocumentContent('echo ok');
+
+    expect(seenOptions).toHaveLength(1);
+    expect(seenOptions[0]?.timeout).toBeGreaterThan(0);
+    expect(seenOptions[0]?.maxBuffer).toBeGreaterThan(1024 * 1024);
+  });
+
+  it('reports a clear timeout error when execFile kills fish_indent for exceeding the deadline', async () => {
+    vi.resetModules();
+    mockFormattingDependencies();
+
+    const execFile: ExecFileMock = vi.fn((_cmd, _args, _options, callback) => {
+      const stdin = new Writable({
+        write(_chunk, _encoding, writeComplete) {
+          writeComplete();
+        },
+      });
+      const childProcess = createMockProcess(stdin);
+
+      setImmediate(() => {
+        const err = new Error('Command failed') as NodeJS.ErrnoException & { killed: boolean; signal: NodeJS.Signals; };
+        err.killed = true;
+        err.signal = 'SIGTERM';
+        callback(err, '', '');
+      });
+
+      return childProcess;
+    });
+
+    vi.doMock('child_process', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('child_process')>();
+      return { ...actual, execFile };
+    });
+
+    const { formatDocumentContent } = await import('../src/formatting');
+
+    await expect(formatDocumentContent('echo waiting')).rejects.toThrow(/timed out/i);
+  });
+
+  it('reports a clear maxBuffer error when fish_indent output exceeds the buffer cap', async () => {
+    vi.resetModules();
+    mockFormattingDependencies();
+
+    const execFile: ExecFileMock = vi.fn((_cmd, _args, _options, callback) => {
+      const stdin = new Writable({
+        write(_chunk, _encoding, writeComplete) {
+          writeComplete();
+        },
+      });
+      const childProcess = createMockProcess(stdin);
+
+      setImmediate(() => {
+        const err = new Error('stdout maxBuffer length exceeded') as NodeJS.ErrnoException;
+        err.code = 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER';
+        callback(err, '', '');
+      });
+
+      return childProcess;
+    });
+
+    vi.doMock('child_process', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('child_process')>();
+      return { ...actual, execFile };
+    });
+
+    const { formatDocumentContent } = await import('../src/formatting');
+
+    await expect(formatDocumentContent('echo too-much')).rejects.toThrow(/exceeded/i);
+  });
+});


### PR DESCRIPTION
* use `execFile()` instead of `exec()` to prevent timeout crashes and related `fish_indent` possible issues in output

* test: tried to reproduce possible issues causing #159 in new file `tests/formatting-child-process.test.ts` (couldn't reproduce #159 during initial write up of this test, mostly guesswork ATM)