### PR TITLE
fix(diagnostic): allows `source (status dirname)/some_file.fish` to resolve

### DIFF
--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -1808,7 +1808,7 @@ export class Analyzer {
       const fromPath = uriToPath(document.uri);
       const baseDir = dirname(fromPath);
 
-      const expanded = getExpandedSourcedFilenameNode(node, baseDir);
+      const expanded = getExpandedSourcedFilenameNode(node, baseDir, fromPath);
       // `source $file` (and other non-literal arguments) can't be expanded to
       // a real path — bail so the caller can fall back to symbol resolution.
       if (!expanded) return [];
@@ -2168,7 +2168,7 @@ export class Analyzer {
     const baseDir = dirname(fromPath);
 
     for (const node of sourceNodes) {
-      const sourced = getExpandedSourcedFilenameNode(node, baseDir);
+      const sourced = getExpandedSourcedFilenameNode(node, baseDir, fromPath);
       if (sourced) {
         sources.add(pathToUri(sourced));
       }
@@ -2568,7 +2568,7 @@ class AnalyzedDocumentCache {
     const fromPath = uriToPath(uri);
     const baseDir = dirname(fromPath);
 
-    const sourceNodes = analyzedDoc.sourceNodes.map((node: any) => getExpandedSourcedFilenameNode(node, baseDir)).filter((s: any) => !!s) as string[];
+    const sourceNodes = analyzedDoc.sourceNodes.map((node: any) => getExpandedSourcedFilenameNode(node, baseDir, fromPath)).filter((s: any) => !!s) as string[];
     for (const source of sourceNodes) {
       const sourceUri = pathToUri(source);
       result.add(sourceUri);

--- a/src/diagnostics/node-types.ts
+++ b/src/diagnostics/node-types.ts
@@ -3,7 +3,7 @@ import { findParentCommand, getCommandNameNode, hasParent, isCommand, isCommandN
 import { getChildNodes, getRange, isNodeWithinOtherNode, precedesRange, TreeWalker } from '../utils/tree-sitter';
 import { Maybe } from '../utils/maybe';
 import { Option } from '../parsing/options';
-import { isExistingSourceFilenameNode, isSourceCommandArgumentName } from '../parsing/source';
+import { getResolvedSourcedFilenameNode, isExistingSourceFilenameNode, isSourceCommandArgumentName } from '../parsing/source';
 import { LspDocument } from '../document';
 import { DiagnosticCommentsHandler } from './comments-handler';
 import { FishSymbol } from '../parsing/symbol';
@@ -146,9 +146,14 @@ export function isUniversalDefinition(node: SyntaxNode): boolean {
   return false;
 }
 
-export function isSourceFilename(node: SyntaxNode): boolean {
+export function isSourceFilename(node: SyntaxNode, baseDir?: string, sourceFilePath?: string): boolean {
   if (isSourceCommandArgumentName(node)) {
-    const isExisting = isExistingSourceFilenameNode(node);
+    // Unknown command substitutions are dynamic. Do not treat their literal
+    // source text as a missing filesystem path.
+    if (getResolvedSourcedFilenameNode(node, baseDir, sourceFilePath) === undefined) {
+      return false;
+    }
+    const isExisting = isExistingSourceFilenameNode(node, baseDir, sourceFilePath);
     if (!isExisting) {
       // check if the node is a variable expansion
       // if it is, do not through a diagnostic because we can't evaluate if this is a valid path

--- a/src/diagnostics/validate.ts
+++ b/src/diagnostics/validate.ts
@@ -8,7 +8,7 @@ import { ErrorCodes } from './error-codes';
 import { config } from '../config';
 import { DiagnosticCommentsHandler } from './comments-handler';
 import { logger } from '../logger';
-import { isAutoloadedUriLoadsFunctionName, uriToReadablePath } from '../utils/translation';
+import { isAutoloadedUriLoadsFunctionName, uriToPath, uriToReadablePath } from '../utils/translation';
 import { FishString } from '../parsing/string';
 import { findParent, findParentCommand, getCommandNameNode, isCommandName, isCommandWithName, isComment, isCompleteCommandName, isFunctionDefinitionName, isOption, isScope, isString, isTopLevelFunctionDefinition } from '../utils/node-types';
 import { isBuiltin, isReservedKeyword } from '../utils/builtins';
@@ -20,6 +20,7 @@ import { findUnreachableCode, sequenceTerminatesAllPaths } from '../parsing/unre
 import { FishDiagnostic } from './types';
 import { server } from '../server';
 import { FishCompletionItemKind } from '../utils/completion/types';
+import { dirname } from 'path';
 
 // Number of nodes to process before yielding to event loop
 const CHUNK_SIZE = 100;
@@ -188,6 +189,8 @@ export async function getDiagnosticsAsync(
 
   // callback to check if the function has an `--event` handler && the handler is enabled at the node
   const isFunctionWithEventHook = isFunctionWithEventHookCallback(doc, handler, allFunctions);
+  const sourceFilePath = uriToPath(doc.uri);
+  const sourceBaseDir = dirname(sourceFilePath);
 
   // Process nodes in chunks to avoid blocking the main thread
   // Using generator for better memory efficiency
@@ -272,7 +275,7 @@ export async function getDiagnosticsAsync(
       );
       if (addDiagnostics(diagnostic)) return diagnostics;
     }
-    if (isSourceFilename(node) && handler.isCodeEnabled(ErrorCodes.sourceFileDoesNotExist)) {
+    if (isSourceFilename(node, sourceBaseDir, sourceFilePath) && handler.isCodeEnabled(ErrorCodes.sourceFileDoesNotExist)) {
       if (addDiagnostics(FishDiagnostic.create(ErrorCodes.sourceFileDoesNotExist, node))) return diagnostics;
     }
 

--- a/src/documentation.ts
+++ b/src/documentation.ts
@@ -40,9 +40,10 @@ export function enrichCommandWithFlags(command: string, description: string, fla
 
 export function handleSourceArgumentHover(analyzer: Analyzer, current: SyntaxNode, document?: LspDocument): Hover | null {
   // Get the base directory for resolving relative paths
-  const baseDir = document ? dirname(uriToPath(document.uri)) : undefined;
+  const sourceFilePath = document ? uriToPath(document.uri) : undefined;
+  const baseDir = sourceFilePath ? dirname(sourceFilePath) : undefined;
 
-  const sourceExpanded = getExpandedSourcedFilenameNode(current, baseDir);
+  const sourceExpanded = getExpandedSourcedFilenameNode(current, baseDir, sourceFilePath);
   if (!sourceExpanded) return null;
   const sourceDoc = analyzer.getDocumentFromPath(sourceExpanded);
   if (!sourceDoc) {

--- a/src/parsing/source.ts
+++ b/src/parsing/source.ts
@@ -14,6 +14,18 @@ import { findFirstExistingFile, isExistingFile } from '../utils/path-resolution'
 
 // TODO think of better naming conventions for these functions
 
+interface SourceResolutionContext {
+  baseDir?: string;
+  sourceFilePath?: string;
+}
+
+const statusFilenameSubcommands = new Set([
+  'filename',
+  'current-filename',
+  '-f',
+  '--current-filename',
+]);
+
 export function isSourceCommandName(node: SyntaxNode) {
   return isCommandWithName(node, 'source') || isCommandWithName(node, '.');
 }
@@ -50,47 +62,170 @@ export function isSourcedFilename(node: SyntaxNode) {
   return false;
 }
 
-export function isExistingSourceFilenameNode(node: SyntaxNode, baseDir?: string) {
-  if (!isSourcedFilename(node)) return false;
-  const resolvedPath = resolveSourcePath(node.text, baseDir);
-  return resolvedPath && isExistingFile(resolvedPath);
+export function getResolvedSourcedFilenameNode(
+  node: SyntaxNode,
+  baseDir?: string,
+  sourceFilePath?: string,
+): string | undefined {
+  if (!isSourcedFilename(node)) return undefined;
+  return resolveSourcePath(node, { baseDir, sourceFilePath });
 }
 
-export function getExpandedSourcedFilenameNode(node: SyntaxNode, baseDir?: string) {
-  if (!isSourcedFilename(node)) return undefined;
+export function isExistingSourceFilenameNode(
+  node: SyntaxNode,
+  baseDir?: string,
+  sourceFilePath?: string,
+): boolean {
+  const resolvedPath = getResolvedSourcedFilenameNode(node, baseDir, sourceFilePath);
+  return !!resolvedPath && isExistingFile(resolvedPath);
+}
 
-  const resolvedPath = resolveSourcePath(node.text, baseDir);
+export function getExpandedSourcedFilenameNode(
+  node: SyntaxNode,
+  baseDir?: string,
+  sourceFilePath?: string,
+): string | undefined {
+  const resolvedPath = getResolvedSourcedFilenameNode(node, baseDir, sourceFilePath);
   if (resolvedPath && isExistingFile(resolvedPath)) {
     return SyncFileHelper.expandEnvVars(resolvedPath);
   }
   return undefined;
 }
 
+function evaluateCommandArgument(node: SyntaxNode, context: SourceResolutionContext): string | undefined {
+  if (node.type === 'command_substitution') {
+    return evaluateCommandSubstitution(node, context);
+  }
+  return node.text;
+}
+
+/**
+ * Evaluates only deterministic commands used to derive paths from the current
+ * script. `stdin` is supplied when the command is part of a supported pipe.
+ */
+function evaluatePathCommand(
+  node: SyntaxNode,
+  context: SourceResolutionContext,
+  stdin?: string,
+): string | undefined {
+  if (node.type !== 'command') return undefined;
+
+  const commandName = node.childForFieldName('name')?.text;
+  const args = node.childrenForFieldName('argument');
+
+  if (commandName === 'status' && stdin === undefined && args.length === 1) {
+    const subcommand = args[0]?.text;
+    if (subcommand === 'dirname') return context.baseDir;
+    if (subcommand === 'basename') {
+      return context.sourceFilePath ? path.basename(context.sourceFilePath) : undefined;
+    }
+    if (subcommand && statusFilenameSubcommands.has(subcommand)) {
+      return context.sourceFilePath;
+    }
+    return undefined;
+  }
+
+  if (commandName === 'dirname' && stdin === undefined && args.length === 1) {
+    const operand = evaluateCommandArgument(args[0]!, context);
+    return operand === undefined ? undefined : dirname(operand);
+  }
+
+  if (commandName !== 'path' || args[0]?.text !== 'dirname') return undefined;
+
+  if (stdin !== undefined && args.length === 1) {
+    return dirname(stdin);
+  }
+  if (stdin === undefined && args.length === 2) {
+    const operand = evaluateCommandArgument(args[1]!, context);
+    return operand === undefined ? undefined : dirname(operand);
+  }
+  return undefined;
+}
+
+function evaluateCommandSubstitution(node: SyntaxNode, context: SourceResolutionContext): string | undefined {
+  const expression = node.firstNamedChild;
+  if (!expression) return undefined;
+
+  const flattenPipeline = (current: SyntaxNode): SyntaxNode[] | undefined => {
+    if (current.type === 'command') return [current];
+    if (current.type !== 'pipe') return undefined;
+
+    const commands: SyntaxNode[] = [];
+    for (const child of current.namedChildren) {
+      const nested = flattenPipeline(child);
+      if (!nested) return undefined;
+      commands.push(...nested);
+    }
+    return commands;
+  };
+
+  const commands = flattenPipeline(expression);
+  if (!commands || commands.length === 0) return undefined;
+  if (commands.length === 1) {
+    return evaluatePathCommand(commands[0]!, context);
+  }
+
+  let output: string | undefined;
+  for (const [index, command] of commands.entries()) {
+    output = evaluatePathCommand(command, context, index === 0 ? undefined : output);
+    if (output === undefined) return undefined;
+  }
+  return output;
+}
+
+/**
+ * Expands deterministic command substitutions while preserving literal and
+ * environment-variable path fragments for the existing path resolver.
+ */
+function evaluateSourceArgument(node: SyntaxNode, context: SourceResolutionContext): string | undefined {
+  if (node.type === 'command_substitution') {
+    return evaluateCommandSubstitution(node, context);
+  }
+  if (node.type !== 'concatenation') {
+    return node.text;
+  }
+
+  const parts: string[] = [];
+  for (const child of node.namedChildren) {
+    if (child.type === 'command_substitution') {
+      const expanded = evaluateCommandSubstitution(child, context);
+      if (expanded === undefined) return undefined;
+      parts.push(expanded);
+    } else {
+      parts.push(child.text);
+    }
+  }
+  return parts.join('');
+}
+
 /**
  * Resolves a source path that might be relative, relative to the base directory
- * @param sourcePath The path from the source command (e.g., "./scripts/file.fish", "/abs/path.fish")
- * @param baseDir The directory to resolve relative paths against (usually the directory containing the sourcing script)
- * @returns The resolved absolute path, or the original path if it was already absolute
+ * @param node The source command's filename argument
+ * @param context Information about the document containing the source command
+ * @returns The resolved path candidate, or `undefined` for a dynamic expression
  */
-function resolveSourcePath(sourcePath: string, baseDir?: string): string {
+function resolveSourcePath(node: SyntaxNode, context: SourceResolutionContext): string | undefined {
+  const sourcePath = evaluateSourceArgument(node, context);
+  if (sourcePath === undefined) return undefined;
+
   // Expand environment variables first
   const expandedPath = SyncFileHelper.expandEnvVars(sourcePath);
 
-  // If it's already an absolute path, return as-is
+  // Normalize absolute paths before using them as document/source graph keys.
   if (isAbsolute(expandedPath)) {
-    return expandedPath;
+    return path.normalize(expandedPath);
   }
 
   // Try to find the file in multiple possible locations
   const foundPath = findFirstExistingFile(
-    path.join(baseDir || workspaceManager.current?.path || process.cwd(), expandedPath),
+    path.join(context.baseDir || workspaceManager.current?.path || process.cwd(), expandedPath),
     path.resolve(process.cwd(), expandedPath),
     path.resolve(process.env.PWD || '', expandedPath),
     path.resolve(workspaceManager.current?.path || '', expandedPath),
   );
 
   // Return the found path or the expanded path as fallback
-  return foundPath ?? expandedPath;
+  return path.normalize(foundPath ?? expandedPath);
 }
 
 export interface SourceResource {
@@ -148,11 +283,11 @@ export function createSourceResources(analyzer: Analyzer, from: LspDocument): So
   const baseDir = dirname(fromPath);
 
   const nodes = analyzer.getNodes(from.uri).filter(n => {
-    return isSourceCommandArgumentName(n) && !!isExistingSourceFilenameNode(n, baseDir);
+    return isSourceCommandArgumentName(n) && !!isExistingSourceFilenameNode(n, baseDir, fromPath);
   });
   if (nodes.length === 0) return result;
   for (const node of nodes) {
-    const sourcedFile = getExpandedSourcedFilenameNode(node, baseDir);
+    const sourcedFile = getExpandedSourcedFilenameNode(node, baseDir, fromPath);
     if (!sourcedFile) continue;
     const to = analyzer.getDocumentFromPath(sourcedFile) ||
       SyncFileHelper.toLspDocument(sourcedFile);

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -17,7 +17,7 @@ import { withTempFishFile } from './temp';
 import { workspaceManager } from '../src/utils/workspace-manager';
 // import { Option } from '../src/parsing/options';
 import { getNoExecuteDiagnostics } from '../src/diagnostics/no-execute-diagnostic';
-import { analyzer, Analyzer } from '../src/analyze';
+import { AnalyzedDocument, analyzer, Analyzer } from '../src/analyze';
 import { config, getDefaultConfiguration } from '../src/config';
 import { setupProcessEnvExecFile } from '../src/utils/process-env';
 import { logger } from '../src/logger';
@@ -1455,6 +1455,270 @@ describe('diagnostics with missing completions', () => {
       getGroupedCompletionSymbolsAsArgparse(completionGroups, flatAutoloadedSymbols);
 
       findAllMissingArgparseFlags(functionDoc);
+    });
+  });
+
+  describe('source command syntax `source (status dirname)/*.fish` verification', () => {
+    let mainCached: AnalyzedDocument;
+    let test1Cached: AnalyzedDocument;
+    let test2Cached: AnalyzedDocument;
+    let test3Cached: AnalyzedDocument;
+    let test4Cached: AnalyzedDocument;
+    let test5Cached: AnalyzedDocument;
+    let test6Cached: AnalyzedDocument;
+    let test7Cached: AnalyzedDocument;
+
+    const workspace = TestWorkspace.create()
+      .addFiles(
+        // a source file that defines my_func
+        TestFile.custom('v1/my_func.fish', [
+          'function my_func',
+          '  argparse a/arg1 h/help -- $argv',
+          '  or return',
+          '  if set -ql _flag_help',
+          '   echo "help msg"',
+          '   return 0',
+          '  end',
+          '  echo "hello world!"',
+          '  set -ql _flag_arg1',
+          '  and echo "arg1 is set! $_flag_arg1"',
+          'end',
+          'complete -c my_function -f',
+          'complete -c my_function -s a -l arg1 -d "Argument 1"',
+          'complete -c my_function -s h -l help -d "help msg"',
+        ].join('\n')),
+        // sources my_func and checks that it exists, should not report any diagnostics
+        TestFile.custom('v1/my_func_test1.fish', [
+          'source (status dirname)/my_func.fish',
+          'my_func --help && test "$status" -eq 0',
+        ].join('\n')),
+        // sources my_func and checks that it exists, should not report any diagnostics
+        TestFile.custom('v1/my_func_test2.fish', [
+          'source $(status dirname)/my_func.fish',
+          'my_func --help && test "$status" -eq 0',
+        ].join('\n')),
+        // sources a file that does not exist, should report diagnostics
+        TestFile.custom('v1/my_func_test3.fish', [
+          'source (status dirname)/function_that_dne.fish',
+          'my_func --help && test "$status" -eq 0',
+        ].join('\n')),
+        // sources a file that does not exist, should report diagnostics
+        TestFile.custom('v1/my_func_test4.fish', [
+          'source (status basename)/function_that_dne.fish',
+          'my_func --help && test "$status" -eq 0',
+        ].join('\n')),
+        // sources a file that does not exist, but is quoted, should not report diagnostics
+        TestFile.custom('v1/my_func_test5.fish', [
+          'source "$(status basename)/function_that_dne.fish"',
+          'my_func --help && test "$status" -eq 0',
+        ].join('\n')),
+        // sources a file that exists, should not report diagnostics
+        TestFile.custom('v1/my_func_test6.fish', [
+          'source ./my_func.fish',
+          'my_func --help && test "$status" -eq 0',
+        ].join('\n')),
+        // sources a file that does not exist, should report diagnostics
+        TestFile.custom('v1/my_func_test7.fish', [
+          'source (status dirname)/no_func.fish',
+          '# no_func DNE, should still error',
+        ].join('\n')),
+
+      ).initialize();
+
+    beforeEach(async () => {
+      // cached documents for the tests
+      mainCached = analyzer.analyze(workspace.getDocument('v1/my_func.fish')!);
+      test1Cached = analyzer.analyze(workspace.getDocument('v1/my_func_test1.fish')!);
+      test2Cached = analyzer.analyze(workspace.getDocument('v1/my_func_test2.fish')!);
+      test3Cached = analyzer.analyze(workspace.getDocument('v1/my_func_test3.fish')!);
+      test4Cached = analyzer.analyze(workspace.getDocument('v1/my_func_test4.fish')!);
+      test5Cached = analyzer.analyze(workspace.getDocument('v1/my_func_test5.fish')!);
+      test6Cached = analyzer.analyze(workspace.getDocument('v1/my_func_test6.fish')!);
+      test7Cached = analyzer.analyze(workspace.getDocument('v1/my_func_test7.fish')!);
+    });
+
+    afterEach(async () => {
+      Object.assign(config, getDefaultConfiguration());
+    });
+
+    it.skip('validate: workspace files', () => {
+      expect(mainCached).toBeDefined();
+      expect(test1Cached).toBeDefined();
+      expect(test2Cached).toBeDefined();
+      expect(test3Cached).toBeDefined();
+      expect(test4Cached).toBeDefined();
+      expect(test5Cached).toBeDefined();
+      expect(test6Cached).toBeDefined();
+      expect(test7Cached).toBeDefined();
+      console.log(workspace.dumpFileTree());
+    });
+
+    it('DOES NOT REPORT existing files for EITHER command substitution syntax: `(status dirname)`/`$(status dirname)`', async () => {
+      // gather diagnostics for test1 and test2
+      const test1Diagnostics = await getDiagnosticsAsync(test1Cached.root!, test1Cached.document);
+      const test2Diagnostics = await getDiagnosticsAsync(test2Cached.root!, test2Cached.document);
+      expect(test1Diagnostics).not.toContainEqual(expect.objectContaining({ code: ErrorCodes.sourceFileDoesNotExist }));
+      expect(test2Diagnostics).not.toContainEqual(expect.objectContaining({ code: ErrorCodes.sourceFileDoesNotExist }));
+
+      // expect sources to contain mainDoc.uri
+      expect(analyzer.collectAllSources(test1Cached.document.uri)).toContain(mainCached.document.uri);
+      expect(analyzer.collectAllSources(test2Cached.document.uri)).toContain(mainCached.document.uri);
+      // expect no diagnostics
+      expect(test1Diagnostics).toHaveLength(0);
+      expect(test2Diagnostics).toHaveLength(0);
+    });
+
+    it('reports missing files command substitution syntax in \'v1/my_func_test3.fish\'', async () => {
+      const test3Diagnostics = await getDiagnosticsAsync(test3Cached.root!, test3Cached.document);
+      expect(test3Diagnostics).toContainEqual(expect.objectContaining({
+        code: ErrorCodes.sourceFileDoesNotExist,
+        message: 'source filename does not exist',
+        range: { start: { line: 0, character: 7 }, end: { line: 0, character: 46 } },
+      }));
+    });
+
+    it('reports missing files command substitution syntax for `status basename` in \'v1/my_func_test4.fish\'', async () => {
+      const test4Diagnostics = await getDiagnosticsAsync(test4Cached.root!, test4Cached.document);
+      expect(test4Diagnostics).toContainEqual(expect.objectContaining({
+        code: ErrorCodes.sourceFileDoesNotExist,
+        message: 'source filename does not exist',
+        range: { start: { line: 0, character: 7 }, end: { line: 0, character: 47 } },
+      }));
+    });
+
+    it('doesn\'t report quoted "$(status basename)/function_that_dne.fish" in \'v1/my_func_test5.fish\'', async () => {
+      const test5Diagnostics = await getDiagnosticsAsync(test5Cached.root!, test5Cached.document);
+      expect(test5Diagnostics).not.toContainEqual(expect.objectContaining({
+        code: ErrorCodes.sourceFileDoesNotExist,
+        message: 'source filename does not exist',
+      }));
+    });
+
+    it('VALID filename `./my_func.fish` sourced in v1/my_func_test6.fish', async () => {
+      const test6Diagnostics = getDiagnosticsAsync(test6Cached.root!, test6Cached.document);
+      await expect(test6Diagnostics).resolves.toHaveLength(0);
+    });
+
+    it('INVALID filename `(status dirname)/no_func.fish` sourced in v1/my_func_test7.fish', async () => {
+      const test7Diagnostics = getDiagnosticsAsync(test7Cached.root!, test7Cached.document);
+      await expect(test7Diagnostics).resolves.toHaveLength(1);
+      await expect(test7Diagnostics).resolves.toContainEqual(expect.objectContaining({
+        code: ErrorCodes.sourceFileDoesNotExist,
+        message: 'source filename does not exist',
+        range: { start: { line: 0, character: 7 }, end: { line: 0, character: 36 } },
+      }));
+    });
+  });
+
+  describe('static source paths derived from status filename', () => {
+    const supportedSources = [
+      'source (dirname (status filename))/helper.fish',
+      'source $(dirname $(status filename))/helper.fish',
+      'source (path dirname (status filename))/helper.fish',
+      'source $(path dirname $(status current-filename))/helper.fish',
+      'source (path dirname (status -f))/helper.fish',
+      'source $(path dirname $(status --current-filename))/helper.fish',
+      'source (status filename | path dirname)/helper.fish',
+      'source $(status filename | path dirname)/helper.fish',
+      'source (status current-filename | path dirname)/helper.fish',
+      'source $(status -f | path dirname)/helper.fish',
+    ];
+    const missingSources = [
+      'source (path dirname (status filename))/missing.fish',
+      'source (status filename | path dirname)/missing.fish',
+    ];
+    const dynamicSources = [
+      'source (status current-command | path dirname)/missing.fish',
+      'source (status filename | path normalize)/missing.fish',
+    ];
+    const parentSources = [
+      'source (status dirname)/../parent_helper.fish',
+      'source $(status dirname)/../parent_helper.fish',
+      'source (path dirname (status dirname))/parent_helper.fish',
+      'source $(path dirname $(status dirname))/parent_helper.fish',
+      'source (path dirname (path dirname (status filename)))/parent_helper.fish',
+      'source $(path dirname $(path dirname $(status filename)))/parent_helper.fish',
+      'source (dirname (dirname (status filename)))/parent_helper.fish',
+      'source (status filename | path dirname | path dirname)/parent_helper.fish',
+      'source $(status filename | path dirname | path dirname)/parent_helper.fish',
+    ];
+    const missingParentSources = [
+      'source (status dirname)/../missing_parent.fish',
+      'source (status filename | path dirname | path dirname)/missing_parent.fish',
+    ];
+    const workspace = TestWorkspace.create()
+      .addFiles(
+        TestFile.custom('parent_helper.fish', 'true'),
+        TestFile.custom('v2/helper.fish', 'true'),
+        ...supportedSources.map((source, index) => TestFile.custom(`v2/supported_${index}.fish`, source)),
+        ...missingSources.map((source, index) => TestFile.custom(`v2/missing_${index}.fish`, source)),
+        ...dynamicSources.map((source, index) => TestFile.custom(`v2/dynamic_${index}.fish`, source)),
+        ...parentSources.map((source, index) => TestFile.custom(`v2/parent_${index}.fish`, source)),
+        ...missingParentSources.map((source, index) => TestFile.custom(`v2/missing_parent_${index}.fish`, source)),
+        TestFile.custom('v2/direct_filename.fish', 'source (status filename).copy'),
+        TestFile.custom('v2/direct_filename.fish.copy', 'true'),
+      ).initialize();
+
+    it('resolves nested and piped expressions to the same sibling file', async () => {
+      const helperDoc = workspace.getDocument('v2/helper.fish')!;
+      analyzer.analyze(helperDoc);
+
+      for (const [index] of supportedSources.entries()) {
+        const document = workspace.getDocument(`v2/supported_${index}.fish`)!;
+        const cached = analyzer.analyze(document);
+        const diagnostics = await getDiagnosticsAsync(cached.root!, document);
+        expect(diagnostics).not.toContainEqual(expect.objectContaining({ code: ErrorCodes.sourceFileDoesNotExist }));
+        expect(analyzer.collectAllSources(document.uri)).toContain(helperDoc.uri);
+      }
+    });
+
+    it('resolves status filename itself when it is part of a larger path', async () => {
+      const document = workspace.getDocument('v2/direct_filename.fish')!;
+      const target = workspace.getDocument('v2/direct_filename.fish.copy')!;
+      const cached = analyzer.analyze(document);
+      const diagnostics = await getDiagnosticsAsync(cached.root!, document);
+      expect(diagnostics).not.toContainEqual(expect.objectContaining({ code: ErrorCodes.sourceFileDoesNotExist }));
+      expect(analyzer.collectAllSources(document.uri)).toContain(target.uri);
+    });
+
+    it('reports missing files after deterministic nested and piped resolution', async () => {
+      for (const [index] of missingSources.entries()) {
+        const document = workspace.getDocument(`v2/missing_${index}.fish`)!;
+        const cached = analyzer.analyze(document);
+        const diagnostics = await getDiagnosticsAsync(cached.root!, document);
+        expect(diagnostics).toContainEqual(expect.objectContaining({ code: ErrorCodes.sourceFileDoesNotExist }));
+      }
+    });
+
+    it('does not guess at unsupported commands or pipeline stages', async () => {
+      for (const [index] of dynamicSources.entries()) {
+        const document = workspace.getDocument(`v2/dynamic_${index}.fish`)!;
+        const cached = analyzer.analyze(document);
+        const diagnostics = await getDiagnosticsAsync(cached.root!, document);
+        expect(diagnostics).not.toContainEqual(expect.objectContaining({ code: ErrorCodes.sourceFileDoesNotExist }));
+      }
+    });
+
+    it('normalizes literal and computed parent-directory paths', async () => {
+      const target = workspace.getDocument('parent_helper.fish')!;
+      analyzer.analyze(target);
+
+      for (const [index] of parentSources.entries()) {
+        const document = workspace.getDocument(`v2/parent_${index}.fish`)!;
+        const cached = analyzer.analyze(document);
+        const diagnostics = await getDiagnosticsAsync(cached.root!, document);
+        expect(diagnostics).not.toContainEqual(expect.objectContaining({ code: ErrorCodes.sourceFileDoesNotExist }));
+        expect(analyzer.collectAllSources(document.uri)).toContain(target.uri);
+      }
+    });
+
+    it('reports missing files after resolving a parent directory', async () => {
+      for (const [index] of missingParentSources.entries()) {
+        const document = workspace.getDocument(`v2/missing_parent_${index}.fish`)!;
+        const cached = analyzer.analyze(document);
+        const diagnostics = await getDiagnosticsAsync(cached.root!, document);
+        expect(diagnostics).toContainEqual(expect.objectContaining({ code: ErrorCodes.sourceFileDoesNotExist }));
+      }
     });
   });
 });


### PR DESCRIPTION
test: further improvements to `source` diagnostics

feat: recursive `source (status dirname | path dirname | path dirname)`

* tests verifying different combinations of $argv vs pipes for `source` resolution

* relative path in combination with source syntax support works:

  ```fish source (status filename | path dirname)../../some_file.fish # finds some_file.fish ```

* multiple chained operations are resolvable