### PR TITLE
fix: symbol definition regression introduced in 1.1.4-pre.3

### DIFF
--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -1066,7 +1066,7 @@ export class Analyzer {
             // nested `_foo`) would otherwise be indistinguishable here and
             // the first matching parent — typically the erased one — wins.
             const callerVar = this.symbols.findDocumentVariables(caller.uri, word).find(s =>
-              !!s.parent && s.parent.equals(caller),
+              s.getFunctionOwner()?.equals(caller),
             );
             if (callerVar) {
               symbols.push(callerVar);
@@ -1172,9 +1172,12 @@ export class Analyzer {
       if (symbol) return symbol;
     }
     const result = symbols.pop() || null;
+    const resultFunction = result?.isVariable()
+      ? result.getFunctionOwner()
+      : undefined;
     // For variables inside --no-scope-shadowing functions, resolve to the root
     // definition in the caller chain
-    if (result?.isVariable() && result.parent?.isFunctionWithNoScopeShadowing()) {
+    if (result?.isVariable() && resultFunction?.isFunctionWithNoScopeShadowing()) {
       return this.resolveNoScopeShadowingDefinition(result);
     }
     // For --inherit-variable symbols, resolve to the caller's definition
@@ -1184,9 +1187,9 @@ export class Analyzer {
     // For variables inside a function that inherits this variable name,
     // resolve to the caller's definition (e.g., B has --inherit-variable VAR
     // and also `set VAR ...` — the true definition is in the caller)
-    if (result?.isVariable() && result.parent?.hasInheritedVariable(result.name)) {
+    if (result?.isVariable() && resultFunction?.hasInheritedVariable(result.name)) {
       // Find the --inherit-variable declaration symbol for this variable
-      const inheritDecl = result.parent.children
+      const inheritDecl = resultFunction.children
         .find((c: FishSymbol) => c.name === result.name && c.isInheritVariable());
       if (inheritDecl) {
         return this.resolveInheritVariableDefinition(inheritDecl) || result;
@@ -1247,11 +1250,12 @@ export class Analyzer {
    * @returns the root definition symbol, or the input symbol if no caller chain exists
    */
   public resolveNoScopeShadowingDefinition(varSymbol: FishSymbol): FishSymbol {
-    if (!varSymbol.isVariable() || !varSymbol.parent?.isFunctionWithNoScopeShadowing()) {
+    const enclosingFunction = varSymbol.getFunctionOwner();
+    if (!varSymbol.isVariable() || !enclosingFunction?.isFunctionWithNoScopeShadowing()) {
       return varSymbol;
     }
 
-    let currentFunc = varSymbol.parent;
+    let currentFunc = enclosingFunction;
     let rootVar = varSymbol;
     const visited = new Set<string>();
 
@@ -1267,7 +1271,7 @@ export class Analyzer {
       // an erased top-level `_foo` and a nested `_foo`) don't collide on
       // their implicit `argv` children.
       const callerVar = this.symbols.findDocumentVariables(caller.uri, varSymbol.name).find(s =>
-        !!s.parent && s.parent.equals(caller),
+        s.getFunctionOwner()?.equals(caller),
       );
       if (!callerVar) break;
 
@@ -1342,7 +1346,7 @@ export class Analyzer {
 
       // Found a caller — look for the variable definition in it
       const callerVar = this.symbols.findDocumentVariables(sym.uri, inheritSymbol.name).find(s =>
-        s.parent?.name === sym.name
+        s.getFunctionOwner()?.equals(sym)
         && !s.isInheritVariable(),
       );
       if (callerVar) {
@@ -1382,7 +1386,7 @@ export class Analyzer {
 
       // Found a script-level caller — look for a root-level variable definition
       const rootVar = this.symbols.findDocumentVariables(uri, inheritSymbol.name).find(s =>
-        !s.parent?.isFunction()
+        !s.getFunctionOwner()
         && !s.isInheritVariable(),
       );
       if (rootVar) return rootVar;
@@ -1698,7 +1702,7 @@ export class Analyzer {
         const scopeNode = symbol.scope.scopeNode;
         if (scopeNode) {
           const noScopeFuncs = this.symbols.noScopeShadowing.allSymbols.filter(f => {
-            if (!this.isFunctionVisibleFrom(f, symbol.parent, symbol.uri)) return false;
+            if (!this.isFunctionVisibleFrom(f, symbol.getFunctionOwner(), symbol.uri)) return false;
             if (f.children.some(c => c.isVariable() && c.name === symbol.name)) return true;
             for (const n of nodesGen(f.scopeNode)) {
               if (isVariableExpansionWithName(n, symbol.name)) return true;
@@ -1719,7 +1723,11 @@ export class Analyzer {
       // inherits it via `--inherit-variable name` is called inside the var's
       // scope.
       if (symbol.isVariable() && this.symbols.inheritedVariables.has(symbol.name)) {
-        const inheritingFuncs = this.getCallableInheritingFunctions(symbol.name, symbol.parent, symbol.uri);
+        const inheritingFuncs = this.getCallableInheritingFunctions(
+          symbol.name,
+          symbol.getFunctionOwner(),
+          symbol.uri,
+        );
         const scopeNode = symbol.scope.scopeNode;
         if (scopeNode) {
           for (const n of nodesGen(scopeNode)) {
@@ -1762,7 +1770,7 @@ export class Analyzer {
    * than its own definition.
    */
   private isUsedViaNoScopeShadowingRoot(symbol: FishSymbol): boolean {
-    if (!symbol.isVariable() || !symbol.parent?.isFunctionWithNoScopeShadowing()) {
+    if (!symbol.isVariable() || !symbol.getFunctionOwner()?.isFunctionWithNoScopeShadowing()) {
       return false;
     }
     const rootSymbol = this.resolveNoScopeShadowingDefinition(symbol);
@@ -1787,7 +1795,7 @@ export class Analyzer {
         && !definitionSymbol.equalScopes(s)
         && s.name === definitionSymbol.name
         && s.kind === definitionSymbol.kind
-        && !s.parent?.isFunctionWithNoScopeShadowing()
+        && !s.getFunctionOwner()?.isFunctionWithNoScopeShadowing()
         && !s.isInheritVariable(),
       );
     }

--- a/src/parsing/equality-utils.ts
+++ b/src/parsing/equality-utils.ts
@@ -147,6 +147,13 @@ const haveCompatibleScopeTags: ScopeCheck = ({ a, b }) => {
 
 // Check if scopes are equal
 const haveEqualScopes: ScopeCheck = ({ a, b }) => {
+  // Reflexivity must be explicit: the containment checks below are
+  // lifetime-aware (see FishSymbol.scopeContainsNode), so a definition's own
+  // command node — which starts at the `set`/`read` keyword, before the
+  // definition's name token — is deliberately rejected by them. Compare by
+  // definition site (equalSymbols), NOT by scope node: erase-separated
+  // re-definitions share a scope node but are distinct bindings.
+  if (equalSymbols(a, b)) return true;
   if (!haveSameScopeNode({ a, b }) || a.kind !== b.kind) return false;
   return haveCompatibleScopeTags({ a, b });
 };
@@ -196,26 +203,37 @@ const checkGeneralScopeContainment: ScopeCheck = ({ a, b }) => {
   return a.scope.scopeTag === b.scope.scopeTag;
 };
 
-/**
- * Two LOCAL variables belong to the same scope chain only when they share the
- * same owning function (FishSymbol.parent identity), or both sit at script /
- * program top level (no parent). fish never leaks a script/outer local into a
- * nested function body, so a function's `$argv` is a distinct variable from the
- * script's implicit file-level `argv`.
- *
- * Using `.parent` rather than SyntaxNode traversal is deliberate: only
- * functions are internal nodes in the FishSymbol tree (if/for/while blocks are
- * not symbols), so `.parent` is always the enclosing function symbol — block-
- * level and body-level locals in the same function therefore still share an
- * owner. Mirrors the `equalParents` idiom in `FishSymbol.equalArgparse`.
- */
+/** Local variables share an owner only within the same lexical function. */
 const sharesLocalOwner = (a: FishSymbol, b: FishSymbol): boolean => {
-  return a.parent && b.parent
-    ? a.parent.equals(b.parent)
-    : !a.parent && !b.parent;
+  const aOwner = a.getFunctionOwner();
+  const bOwner = b.getFunctionOwner();
+  return aOwner && bOwner ? aOwner.equals(bOwner) : !aOwner && !bOwner;
 };
 
-// Main scope containment checker
+const hasExplicitVariableScope = (symbol: FishSymbol): boolean => {
+  if (!symbol.isVariable()) return false;
+  return symbol.options.some(option =>
+    option.isOption('-U', '--universal')
+    || option.isOption('-g', '--global')
+    || option.isOption('-f', '--function')
+    || option.isOption('-l', '--local'),
+  );
+};
+
+/**
+ * Main scope containment checker.
+ *
+ * The check sequence is load-bearing — each guard must run before the
+ * shortcut it protects:
+ *   1. owner guard — rejects cross-function pairs before any positional
+ *      shortcut, since an outer local's scope node can physically span a
+ *      nested function's body
+ *   2. explicit-scope guard — rejects explicit `-U/-g/-f/-l` re-scopes before
+ *      `haveEqualScopes`, whose tag matrix treats any two local variables'
+ *      tags as compatible
+ *   3. equal scopes — trivially contained (also carries reflexivity)
+ *   4. kind-specific positional containment fallbacks
+ */
 export const symbolContainsScope = (symbolA: FishSymbol, symbolB: FishSymbol): boolean => {
   const pair: SymbolPair = { a: symbolA, b: symbolB };
 
@@ -229,6 +247,21 @@ export const symbolContainsScope = (symbolA: FishSymbol, symbolB: FishSymbol): b
     symbolA.isVariable() && symbolB.isVariable()
     && symbolA.isLocal() && symbolB.isLocal()
     && !sharesLocalOwner(symbolA, symbolB)
+  ) {
+    return false;
+  }
+
+  // An explicit scope modifier creates or targets that exact scope. It must
+  // not be folded into an enclosing binding merely because the enclosing
+  // scope contains its command. Unscoped writes remain eligible to resolve to
+  // the visible outer binding they update.
+  if (
+    symbolA.isVariable() && symbolB.isVariable()
+    && hasExplicitVariableScope(symbolB)
+    && (
+      symbolA.scopeTag !== symbolB.scopeTag
+      || !symbolA.scopeNode.equals(symbolB.scopeNode)
+    )
   ) {
     return false;
   }

--- a/src/parsing/reference-comparator.ts
+++ b/src/parsing/reference-comparator.ts
@@ -160,7 +160,7 @@ const isInValidScope: ReferenceCheck = ({ symbol, document, node }) => {
     }
     // Cross-document: only allow if symbol is in a --no-scope-shadowing function
     // AND the node is also in a --no-scope-shadowing function (or at program scope)
-    if (symbol.parent?.isFunctionWithNoScopeShadowing()) {
+    if (symbol.getFunctionOwner()?.isFunctionWithNoScopeShadowing()) {
       const enclosingFunc = findParentFunction(node);
       if (!enclosingFunc || !isFunctionDefinition(enclosingFunc)) {
         return true; // node is at program/global scope
@@ -168,7 +168,11 @@ const isInValidScope: ReferenceCheck = ({ symbol, document, node }) => {
       const enclosingFuncSymbol = analyzer.getEnclosingFunctionSymbol(document.uri, node);
       return !!(
         enclosingFuncSymbol?.isFunctionWithNoScopeShadowing()
-        && analyzer.isFunctionVisibleFrom(enclosingFuncSymbol, symbol.parent, document.uri)
+        && analyzer.isFunctionVisibleFrom(
+          enclosingFuncSymbol,
+          symbol.getFunctionOwner(),
+          document.uri,
+        )
       );
     }
     // Cross-document: --inherit-variable allows specific variables to cross file boundaries
@@ -405,11 +409,12 @@ function scopeCallsNoScopeShadowingFunctionTransitively(
 function isInNoScopeShadowingCallee(symbol: FishSymbol, node: SyntaxNode, uri: string): boolean {
   const enclosingFuncSymbol = analyzer.getEnclosingFunctionSymbol(uri, node);
   if (!enclosingFuncSymbol?.isFunctionWithNoScopeShadowing()) return false;
-  if (!analyzer.isFunctionVisibleFrom(enclosingFuncSymbol, symbol.parent, uri)) return false;
+  const symbolFunction = symbol.getFunctionOwner();
+  if (!analyzer.isFunctionVisibleFrom(enclosingFuncSymbol, symbolFunction, uri)) return false;
   return scopeCallsNoScopeShadowingFunctionTransitively(
     symbol.scope.scopeNode,
     enclosingFuncSymbol,
-    symbol.parent,
+    symbolFunction,
     symbol.uri,
   );
 }
@@ -432,7 +437,11 @@ function isValidInheritVariableScope(symbol: FishSymbol, node: SyntaxNode, uri: 
 
   // Direction 1: symbol is a regular variable, node is inside a function
   // that inherits this variable via --inherit-variable
-  const inheritingFuncs = analyzer.getCallableInheritingFunctions(symbol.name, symbol.parent, symbol.document.uri);
+  const inheritingFuncs = analyzer.getCallableInheritingFunctions(
+    symbol.name,
+    symbol.getFunctionOwner(),
+    symbol.document.uri,
+  );
   if (inheritingFuncs.some(f => f.equals(enclosingFuncSymbol))) {
     return true;
   }
@@ -467,9 +476,13 @@ function isValidCrossFileVariableReference(symbol: FishSymbol, node: SyntaxNode,
   // Check --no-scope-shadowing
   if (
     enclosingFuncSymbol?.isFunctionWithNoScopeShadowing()
-    && analyzer.isFunctionVisibleFrom(enclosingFuncSymbol, symbol.parent, symbol.document.uri)
+    && analyzer.isFunctionVisibleFrom(
+      enclosingFuncSymbol,
+      symbol.getFunctionOwner(),
+      symbol.document.uri,
+    )
   ) {
-    return symbol.parent?.isFunctionWithNoScopeShadowing() || symbol.isGlobal();
+    return symbol.getFunctionOwner()?.isFunctionWithNoScopeShadowing() || symbol.isGlobal();
   }
   // Check --inherit-variable
   if (isValidInheritVariableScope(symbol, node, uri)) {

--- a/src/parsing/symbol.ts
+++ b/src/parsing/symbol.ts
@@ -602,6 +602,24 @@ export class FishSymbol {
     return this.scope.scopeNode;
   }
 
+  /**
+   * Returns the lexical function that owns this symbol. Definitions inside a
+   * `for` body are children of the loop's FOR symbol, so the direct `parent`
+   * is not necessarily the function owner. The symbol itself is deliberately
+   * excluded: a root function or root-level symbol has no function owner.
+   *
+   * The walk stops only at `FUNCTION`, not at `ALIAS` (the other
+   * `isFunction()` kind): an alias body is a single string token that never
+   * parses into child definitions, so an ALIAS can never be an owner.
+   */
+  getFunctionOwner(): FishSymbol | undefined {
+    let parent = this.parent;
+    while (parent && parent.fishKind !== 'FUNCTION') {
+      parent = parent.parent;
+    }
+    return parent;
+  }
+
   // === Conversion Utils ===
   toString() {
     return SymbolConverters.symbolToString(this);

--- a/tests/duplicate-variable-definition.test.ts
+++ b/tests/duplicate-variable-definition.test.ts
@@ -1,0 +1,669 @@
+import { analyzer, Analyzer } from '../src/analyze';
+import { initializeParser } from '../src/parser';
+import { setupProcessEnvExecFile } from '../src/utils/process-env';
+import { setLogger } from './helpers';
+import TestWorkspace from './test-workspace-utils';
+
+describe('duplicate variable definitions', () => {
+  setLogger();
+
+  beforeEach(async () => {
+    await setupProcessEnvExecFile();
+    await initializeParser();
+    await Analyzer.initialize();
+    await setupProcessEnvExecFile();
+  });
+
+  describe('same-file bindings', () => {
+    const workspace = TestWorkspace.create().addFiles({
+      relativePath: 'my_func.fish',
+      content: [
+        'function my_func',
+        '    set -f var',
+        '    for i in (seq 1 10)',
+        '        set -a var $i',
+        '    end',
+        'end',
+      ].join('\n'),
+    }, {
+      relativePath: 'nested_shadow.fish',
+      content: [
+        'function nested_shadow',
+        '    set -f var outer',
+        '    for i in (seq 1 10)',
+        '        set -l var inner',
+        '    end',
+        'end',
+      ].join('\n'),
+    }, {
+      relativePath: 'erase_and_redefine.fish',
+      content: [
+        'function erase_and_redefine',
+        '    set -f var first',
+        '    set -ef var',
+        '    set -f var second',
+        '    echo $var',
+        'end',
+      ].join('\n'),
+    }, {
+      relativePath: 'same_scope_redefinitions.fish',
+      content: [
+        'function same_scope_redefinitions',
+        '    set -f var first',
+        '    set -a var second',
+        '    set var third',
+        '    echo $var',
+        'end',
+      ].join('\n'),
+    }, {
+      relativePath: 'shadow_and_restore.fish',
+      content: [
+        'function shadow_and_restore',
+        '    set -f var outer',
+        '    echo $var',
+        '    for i in (seq 1 10)',
+        '        set -l var inner',
+        '        echo $var',
+        '    end',
+        '    echo $var',
+        'end',
+      ].join('\n'),
+    }, {
+      relativePath: 'sibling_scopes.fish',
+      content: [
+        'function sibling_scopes',
+        '    for i in (seq 1 10)',
+        '        set -l var first',
+        '        echo $var',
+        '    end',
+        '    for i in (seq 1 10)',
+        '        set -l var second',
+        '        echo $var',
+        '    end',
+        'end',
+      ].join('\n'),
+    }, {
+      relativePath: 'nested_functions.fish',
+      content: [
+        'function outer',
+        '    set -f var outer',
+        '    function inner',
+        '        set -f var inner',
+        '        echo $var',
+        '    end',
+        '    echo $var',
+        'end',
+      ].join('\n'),
+    }).initialize();
+
+    it('resolves a nested append to the first definition in the function scope', () => {
+      const doc = workspace.getDocument('my_func.fish')!;
+
+      const locations = analyzer.getDefinitionLocation(doc, { line: 3, character: 15 });
+
+      expect(locations).toHaveLength(1);
+      expect(locations[0]?.range.start).toEqual({ line: 1, character: 11 });
+    });
+
+    it('keeps both writes associated when references start at the first definition', () => {
+      const doc = workspace.getDocument('my_func.fish')!;
+
+      const references = analyzer.getReferences(doc, { line: 1, character: 11 });
+
+      expect(references.map(location => location.range.start.line)).toEqual([1, 3]);
+    });
+
+    it('keeps an explicit nested local definition separate from the outer function binding', () => {
+      const doc = workspace.getDocument('nested_shadow.fish')!;
+
+      const locations = analyzer.getDefinitionLocation(doc, { line: 3, character: 15 });
+
+      expect(locations).toHaveLength(1);
+      expect(locations[0]?.range.start).toEqual({ line: 3, character: 15 });
+    });
+
+    it('resolves a definition after erase to the new binding', () => {
+      const doc = workspace.getDocument('erase_and_redefine.fish')!;
+
+      const definitionLocations = analyzer.getDefinitionLocation(doc, { line: 3, character: 11 });
+      const referenceLocations = analyzer.getDefinitionLocation(doc, { line: 4, character: 10 });
+
+      expect(definitionLocations).toHaveLength(1);
+      expect(definitionLocations[0]?.range.start).toEqual({ line: 3, character: 11 });
+      expect(referenceLocations).toHaveLength(1);
+      expect(referenceLocations[0]?.range.start).toEqual({ line: 3, character: 11 });
+    });
+
+    it('keeps references on opposite sides of an erase in separate binding lifetimes', () => {
+      const doc = workspace.getDocument('erase_and_redefine.fish')!;
+
+      const firstReferences = analyzer.getReferences(doc, { line: 1, character: 11 });
+      const secondReferences = analyzer.getReferences(doc, { line: 3, character: 11 });
+
+      expect(firstReferences.map(location => location.range.start.line)).toEqual([1, 2]);
+      expect(secondReferences.map(location => location.range.start.line)).toEqual([3, 4]);
+    });
+
+    it('resolves every same-scope write and read to the first definition', () => {
+      const doc = workspace.getDocument('same_scope_redefinitions.fish')!;
+
+      for (const position of [
+        { line: 2, character: 11 },
+        { line: 3, character: 8 },
+        { line: 4, character: 10 },
+      ]) {
+        const locations = analyzer.getDefinitionLocation(doc, position);
+        expect(locations).toHaveLength(1);
+        expect(locations[0]?.range.start).toEqual({ line: 1, character: 11 });
+      }
+    });
+
+    it('uses the nested shadow only inside its block and restores the outer binding afterward', () => {
+      const doc = workspace.getDocument('shadow_and_restore.fish')!;
+
+      const beforeShadow = analyzer.getDefinitionLocation(doc, { line: 2, character: 10 });
+      const shadowDefinition = analyzer.getDefinitionLocation(doc, { line: 4, character: 15 });
+      const insideShadow = analyzer.getDefinitionLocation(doc, { line: 5, character: 14 });
+      const afterShadow = analyzer.getDefinitionLocation(doc, { line: 7, character: 10 });
+
+      expect(beforeShadow[0]?.range.start).toEqual({ line: 1, character: 11 });
+      expect(shadowDefinition[0]?.range.start).toEqual({ line: 4, character: 15 });
+      expect(insideShadow[0]?.range.start).toEqual({ line: 4, character: 15 });
+      expect(afterShadow[0]?.range.start).toEqual({ line: 1, character: 11 });
+    });
+
+    it('keeps same-named explicit locals in sibling blocks independent', () => {
+      const doc = workspace.getDocument('sibling_scopes.fish')!;
+      const definitions = analyzer.getFlatDocumentSymbols(doc.uri)
+        .filter(symbol => symbol.name === 'var' && symbol.fishKind === 'SET');
+
+      expect(definitions).toHaveLength(2);
+      expect(definitions[0]?.getFunctionOwner()?.id).toBe(definitions[1]?.getFunctionOwner()?.id);
+      expect(definitions[0]?.scopeNode.equals(definitions[1]!.scopeNode)).toBe(false);
+
+      const firstReference = analyzer.getDefinitionLocation(doc, { line: 3, character: 14 });
+      const secondDefinition = analyzer.getDefinitionLocation(doc, { line: 6, character: 15 });
+      const secondReference = analyzer.getDefinitionLocation(doc, { line: 7, character: 14 });
+
+      expect(firstReference[0]?.range.start).toEqual({ line: 2, character: 15 });
+      expect(secondDefinition[0]?.range.start).toEqual({ line: 6, character: 15 });
+      expect(secondReference[0]?.range.start).toEqual({ line: 6, character: 15 });
+    });
+
+    it('keeps same-named variables in nested functions isolated by function owner', () => {
+      const doc = workspace.getDocument('nested_functions.fish')!;
+
+      const innerReference = analyzer.getDefinitionLocation(doc, { line: 4, character: 14 });
+      const outerReference = analyzer.getDefinitionLocation(doc, { line: 6, character: 10 });
+
+      expect(innerReference[0]?.range.start).toEqual({ line: 3, character: 15 });
+      expect(outerReference[0]?.range.start).toEqual({ line: 1, character: 11 });
+    });
+  });
+
+  describe('function ownership and non-variable definitions', () => {
+    const workspace = TestWorkspace.create().addFiles({
+      relativePath: 'function_scopes.fish',
+      content: [
+        'function function_scopes',
+        '    function helper',
+        '    end',
+        '    helper',
+        'end',
+        'function helper',
+        'end',
+        'function_scopes',
+        'helper',
+      ].join('\n'),
+    }, {
+      relativePath: 'events.fish',
+      content: [
+        'set -g root_var',
+        'function event_handler --on-event shared_event',
+        'end',
+        'emit shared_event',
+        'emit shared_event',
+        'function event_owner',
+        '    emit nested_event',
+        'end',
+      ].join('\n'),
+    }).initialize();
+
+    it('reports function ownership for root, nested, event, and variable symbols', () => {
+      const functionDoc = workspace.getDocument('function_scopes.fish')!;
+      const functionSymbols = analyzer.getFlatDocumentSymbols(functionDoc.uri);
+      const outer = functionSymbols.find(symbol =>
+        symbol.name === 'function_scopes' && symbol.fishKind === 'FUNCTION',
+      )!;
+      const helpers = functionSymbols.filter(symbol =>
+        symbol.name === 'helper' && symbol.fishKind === 'FUNCTION',
+      );
+      const nestedHelper = helpers.find(symbol => symbol.getFunctionOwner()?.equals(outer))!;
+      const rootHelper = helpers.find(symbol => !symbol.getFunctionOwner())!;
+
+      expect(outer.getFunctionOwner()).toBeUndefined();
+      expect(rootHelper.getFunctionOwner()).toBeUndefined();
+      expect(nestedHelper.getFunctionOwner()?.id).toBe(outer.id);
+
+      const eventDoc = workspace.getDocument('events.fish')!;
+      const eventSymbols = analyzer.getFlatDocumentSymbols(eventDoc.uri);
+      const rootVariable = eventSymbols.find(symbol => symbol.name === 'root_var')!;
+      const handler = eventSymbols.find(symbol =>
+        symbol.name === 'event_handler' && symbol.fishKind === 'FUNCTION',
+      )!;
+      const eventOwner = eventSymbols.find(symbol =>
+        symbol.name === 'event_owner' && symbol.fishKind === 'FUNCTION',
+      )!;
+      const eventHook = eventSymbols.find(symbol => symbol.fishKind === 'FUNCTION_EVENT')!;
+      const rootEmit = eventSymbols.find(symbol =>
+        symbol.name === 'shared_event' && symbol.fishKind === 'EVENT',
+      )!;
+      const nestedEmit = eventSymbols.find(symbol =>
+        symbol.name === 'nested_event' && symbol.fishKind === 'EVENT',
+      )!;
+
+      expect(rootVariable.getFunctionOwner()).toBeUndefined();
+      expect(handler.getFunctionOwner()).toBeUndefined();
+      expect(eventHook.getFunctionOwner()?.id).toBe(handler.id);
+      expect(rootEmit.getFunctionOwner()).toBeUndefined();
+      expect(nestedEmit.getFunctionOwner()?.id).toBe(eventOwner.id);
+    });
+
+    it('resolves same-named nested and root function calls to their own definitions', () => {
+      const doc = workspace.getDocument('function_scopes.fish')!;
+
+      const nestedCall = analyzer.getDefinitionLocation(doc, { line: 3, character: 4 });
+      const rootCall = analyzer.getDefinitionLocation(doc, { line: 8, character: 0 });
+
+      expect(nestedCall).toHaveLength(1);
+      expect(nestedCall[0]?.range.start).toEqual({ line: 1, character: 13 });
+      expect(rootCall).toHaveLength(1);
+      expect(rootCall[0]?.range.start).toEqual({ line: 5, character: 9 });
+    });
+
+    it('keeps event hooks and each emitted event as distinct definition sites', () => {
+      const doc = workspace.getDocument('events.fish')!;
+      const sharedEvents = analyzer.getFlatDocumentSymbols(doc.uri)
+        .filter(symbol => symbol.name === 'shared_event' && symbol.isEvent());
+
+      expect(sharedEvents).toHaveLength(3);
+      for (const event of sharedEvents) {
+        const definitions = analyzer.getDefinitionLocation(doc, event.selectionRange.start);
+        expect(definitions).toHaveLength(1);
+        expect(definitions[0]).toEqual(event.toLocation());
+      }
+    });
+  });
+
+  describe('transparent function bindings', () => {
+    const workspace = TestWorkspace.create().addFiles(
+      {
+        relativePath: 'functions/my_func.fish',
+        content: [
+          'function my_func',
+          '    set -f var',
+          '    shared_append',
+          'end',
+        ].join('\n'),
+      },
+      {
+        relativePath: 'functions/shared_append.fish',
+        content: [
+          'function shared_append --no-scope-shadowing',
+          '    for i in (seq 1 10)',
+          '        set -a var $i',
+          '    end',
+          'end',
+        ].join('\n'),
+      },
+      {
+        relativePath: 'functions/inherit_caller.fish',
+        content: [
+          'function inherit_caller',
+          '    set -f var',
+          '    inherited_append',
+          'end',
+        ].join('\n'),
+      },
+      {
+        relativePath: 'functions/inherited_append.fish',
+        content: [
+          'function inherited_append --inherit-variable var',
+          '    for i in (seq 1 10)',
+          '        set -a var $i',
+          '    end',
+          'end',
+        ].join('\n'),
+      },
+      {
+        relativePath: 'functions/scope_chain_root.fish',
+        content: [
+          'function scope_chain_root',
+          '    set -f chain',
+          '    scope_chain_middle',
+          'end',
+        ].join('\n'),
+      },
+      {
+        relativePath: 'functions/scope_chain_middle.fish',
+        content: [
+          'function scope_chain_middle --no-scope-shadowing',
+          '    for i in (seq 1 10)',
+          '        set -a chain $i',
+          '    end',
+          '    scope_chain_leaf',
+          'end',
+        ].join('\n'),
+      },
+      {
+        relativePath: 'functions/scope_chain_leaf.fish',
+        content: [
+          'function scope_chain_leaf --no-scope-shadowing',
+          '    for i in (seq 1 10)',
+          '        set -a chain $i',
+          '    end',
+          'end',
+        ].join('\n'),
+      },
+      {
+        relativePath: 'functions/inherit_chain_root.fish',
+        content: [
+          'function inherit_chain_root',
+          '    set -f chain',
+          '    inherit_chain_middle',
+          'end',
+        ].join('\n'),
+      },
+      {
+        relativePath: 'functions/inherit_chain_middle.fish',
+        content: [
+          'function inherit_chain_middle --inherit-variable chain',
+          '    for i in (seq 1 10)',
+          '        set -a chain $i',
+          '    end',
+          '    inherit_chain_leaf',
+          'end',
+        ].join('\n'),
+      },
+      {
+        relativePath: 'functions/inherit_chain_leaf.fish',
+        content: [
+          'function inherit_chain_leaf --inherit-variable chain',
+          '    for i in (seq 1 10)',
+          '        set -a chain $i',
+          '    end',
+          'end',
+        ].join('\n'),
+      },
+    ).initialize();
+
+    it('resolves a nested write in a cross-file --no-scope-shadowing function to its caller', () => {
+      const caller = workspace.getDocument('functions/my_func.fish')!;
+      const callee = workspace.getDocument('functions/shared_append.fish')!;
+
+      const locations = analyzer.getDefinitionLocation(callee, { line: 2, character: 15 });
+
+      expect(locations).toHaveLength(1);
+      expect(locations[0]?.uri).toBe(caller.uri);
+      expect(locations[0]?.range.start).toEqual({ line: 1, character: 11 });
+    });
+
+    it('resolves a nested write in an --inherit-variable function to its caller', () => {
+      const caller = workspace.getDocument('functions/inherit_caller.fish')!;
+      const callee = workspace.getDocument('functions/inherited_append.fish')!;
+
+      const locations = analyzer.getDefinitionLocation(callee, { line: 2, character: 15 });
+
+      expect(locations).toHaveLength(1);
+      expect(locations[0]?.uri).toBe(caller.uri);
+      expect(locations[0]?.range.start).toEqual({ line: 1, character: 11 });
+    });
+
+    it('resolves nested writes through a multi-hop --no-scope-shadowing chain', () => {
+      const root = workspace.getDocument('functions/scope_chain_root.fish')!;
+      const middle = workspace.getDocument('functions/scope_chain_middle.fish')!;
+      const leaf = workspace.getDocument('functions/scope_chain_leaf.fish')!;
+
+      const middleLocations = analyzer.getDefinitionLocation(middle, { line: 2, character: 15 });
+      const leafLocations = analyzer.getDefinitionLocation(leaf, { line: 2, character: 15 });
+
+      for (const locations of [middleLocations, leafLocations]) {
+        expect(locations).toHaveLength(1);
+        expect(locations[0]?.uri).toBe(root.uri);
+        expect(locations[0]?.range.start).toEqual({ line: 1, character: 11 });
+      }
+    });
+
+    it('resolves nested writes through a multi-hop --inherit-variable chain', () => {
+      const root = workspace.getDocument('functions/inherit_chain_root.fish')!;
+      const middle = workspace.getDocument('functions/inherit_chain_middle.fish')!;
+      const leaf = workspace.getDocument('functions/inherit_chain_leaf.fish')!;
+
+      const middleLocations = analyzer.getDefinitionLocation(middle, { line: 2, character: 15 });
+      const leafLocations = analyzer.getDefinitionLocation(leaf, { line: 2, character: 15 });
+
+      for (const locations of [middleLocations, leafLocations]) {
+        expect(locations).toHaveLength(1);
+        expect(locations[0]?.uri).toBe(root.uri);
+        expect(locations[0]?.range.start).toEqual({ line: 1, character: 11 });
+      }
+    });
+  });
+
+  describe('common list-building idioms', () => {
+    const workspace = TestWorkspace.create().addFiles({
+      relativePath: 'while_append.fish',
+      content: [
+        'function while_append',
+        '    set -f var',
+        '    while read -l line',
+        '        set -a var $line',
+        '    end',
+        'end',
+      ].join('\n'),
+    }, {
+      relativePath: 'if_append.fish',
+      content: [
+        'function if_append',
+        '    set -f var',
+        '    if test -d /tmp',
+        '        set -a var a',
+        '    else',
+        '        set -p var b',
+        '    end',
+        '    echo $var',
+        'end',
+      ].join('\n'),
+    }, {
+      relativePath: 'nested_for_append.fish',
+      content: [
+        'function nested_for_append',
+        '    set -f matrix',
+        '    for i in (seq 3)',
+        '        for j in (seq 3)',
+        '            set -a matrix $i$j',
+        '        end',
+        '    end',
+        'end',
+      ].join('\n'),
+    }, {
+      relativePath: 'set_q_guard.fish',
+      content: [
+        'function set_q_guard',
+        '    set -q var; or set var default',
+        '    echo $var',
+        'end',
+      ].join('\n'),
+    }, {
+      relativePath: 'command_substitution.fish',
+      content: [
+        'function command_substitution',
+        '    set -f outer (begin; set -l inner 1; echo $inner; end)',
+        '    echo $outer',
+        'end',
+      ].join('\n'),
+    }).initialize();
+
+    it('resolves an append inside a while block to the first definition', () => {
+      const doc = workspace.getDocument('while_append.fish')!;
+
+      const locations = analyzer.getDefinitionLocation(doc, { line: 3, character: 15 });
+
+      expect(locations).toHaveLength(1);
+      expect(locations[0]?.range.start).toEqual({ line: 1, character: 11 });
+    });
+
+    it('resolves a variable read from a while-header `read` definition', () => {
+      const doc = workspace.getDocument('while_append.fish')!;
+
+      const locations = analyzer.getDefinitionLocation(doc, { line: 3, character: 20 });
+
+      expect(locations).toHaveLength(1);
+      expect(locations[0]?.range.start).toEqual({ line: 2, character: 18 });
+    });
+
+    it('resolves appends and prepends in both if branches to the first definition', () => {
+      const doc = workspace.getDocument('if_append.fish')!;
+
+      for (const position of [
+        { line: 3, character: 15 },
+        { line: 5, character: 15 },
+        { line: 7, character: 10 },
+      ]) {
+        const locations = analyzer.getDefinitionLocation(doc, position);
+        expect(locations).toHaveLength(1);
+        expect(locations[0]?.range.start).toEqual({ line: 1, character: 11 });
+      }
+    });
+
+    it('resolves an append two for-loops deep to the function-level definition', () => {
+      const doc = workspace.getDocument('nested_for_append.fish')!;
+
+      const locations = analyzer.getDefinitionLocation(doc, { line: 4, character: 19 });
+
+      expect(locations).toHaveLength(1);
+      expect(locations[0]?.range.start).toEqual({ line: 1, character: 11 });
+    });
+
+    it('resolves a `set -q var; or set var default` guard to the fallback definition', () => {
+      const doc = workspace.getDocument('set_q_guard.fish')!;
+
+      const locations = analyzer.getDefinitionLocation(doc, { line: 2, character: 10 });
+
+      expect(locations).toHaveLength(1);
+      expect(locations[0]?.range.start).toEqual({ line: 1, character: 23 });
+    });
+
+    it('resolves definitions and reads inside a command substitution', () => {
+      const doc = workspace.getDocument('command_substitution.fish')!;
+
+      const innerRead = analyzer.getDefinitionLocation(doc, { line: 1, character: 47 });
+      const outerRead = analyzer.getDefinitionLocation(doc, { line: 2, character: 10 });
+
+      expect(innerRead).toHaveLength(1);
+      expect(innerRead[0]?.range.start).toEqual({ line: 1, character: 32 });
+      expect(outerRead).toHaveLength(1);
+      expect(outerRead[0]?.range.start).toEqual({ line: 1, character: 11 });
+    });
+  });
+
+  describe('explicit scope flags at the same block level', () => {
+    const workspace = TestWorkspace.create().addFiles({
+      relativePath: 'unscoped_then_local.fish',
+      content: [
+        'function unscoped_then_local',
+        '    set var first',
+        '    set -l var second',
+        '    echo $var',
+        'end',
+      ].join('\n'),
+    }, {
+      relativePath: 'unscoped_then_function.fish',
+      content: [
+        'function unscoped_then_function',
+        '    set var first',
+        '    set -f var second',
+        '    echo $var',
+        'end',
+      ].join('\n'),
+    }, {
+      relativePath: 'functions/autoloaded_unscoped_local.fish',
+      content: [
+        'function autoloaded_unscoped_local',
+        '    set var first',
+        '    set -l var second',
+        '    echo $var',
+        'end',
+      ].join('\n'),
+    }, {
+      relativePath: 'functions/autoloaded_unscoped_function.fish',
+      content: [
+        'function autoloaded_unscoped_function',
+        '    set var first',
+        '    set -f var second',
+        '    echo $var',
+        'end',
+      ].join('\n'),
+    }).initialize();
+
+    // These four tests pin behavior that DIVERGES from fish semantics and
+    // depends on file location. In fish, an unscoped `set var` inside a
+    // function is function-scoped, so a later `set -l var` or `set -f var` at
+    // the same block level targets the same slot. The LSP instead derives the
+    // unscoped write's scope tag from the file's autoload type
+    // (getFallbackModifierScope in parsing/set.ts): 'local' in a non-autoloaded
+    // script, 'function' in an autoloaded functions/ file. The explicit-scope
+    // guard in symbolContainsScope then splits any explicit re-scope whose tag
+    // differs — so which flag folds and which starts a new definition site
+    // flips between the two file kinds. If a change unifies the fallback (or
+    // teaches the guard fish's same-slot rule), update these expectations
+    // deliberately.
+    it('folds an explicit -l into the unscoped chain in a non-autoloaded script', () => {
+      const doc = workspace.getDocument('unscoped_then_local.fish')!;
+
+      const explicitLocal = analyzer.getDefinitionLocation(doc, { line: 2, character: 11 });
+      const read = analyzer.getDefinitionLocation(doc, { line: 3, character: 10 });
+
+      expect(explicitLocal).toHaveLength(1);
+      expect(explicitLocal[0]?.range.start).toEqual({ line: 1, character: 8 });
+      expect(read).toHaveLength(1);
+      expect(read[0]?.range.start).toEqual({ line: 1, character: 8 });
+    });
+
+    it('splits an explicit -f into a new definition site in a non-autoloaded script', () => {
+      const doc = workspace.getDocument('unscoped_then_function.fish')!;
+
+      const explicitFunction = analyzer.getDefinitionLocation(doc, { line: 2, character: 11 });
+      const read = analyzer.getDefinitionLocation(doc, { line: 3, character: 10 });
+
+      expect(explicitFunction).toHaveLength(1);
+      expect(explicitFunction[0]?.range.start).toEqual({ line: 2, character: 11 });
+      expect(read).toHaveLength(1);
+      expect(read[0]?.range.start).toEqual({ line: 2, character: 11 });
+    });
+
+    it('folds an explicit -f into the unscoped chain in an autoloaded function file', () => {
+      const doc = workspace.getDocument('functions/autoloaded_unscoped_function.fish')!;
+
+      const explicitFunction = analyzer.getDefinitionLocation(doc, { line: 2, character: 11 });
+      const read = analyzer.getDefinitionLocation(doc, { line: 3, character: 10 });
+
+      expect(explicitFunction).toHaveLength(1);
+      expect(explicitFunction[0]?.range.start).toEqual({ line: 1, character: 8 });
+      expect(read).toHaveLength(1);
+      expect(read[0]?.range.start).toEqual({ line: 1, character: 8 });
+    });
+
+    it('splits an explicit -l into a new shadow site in an autoloaded function file', () => {
+      const doc = workspace.getDocument('functions/autoloaded_unscoped_local.fish')!;
+
+      const explicitLocal = analyzer.getDefinitionLocation(doc, { line: 2, character: 11 });
+      const read = analyzer.getDefinitionLocation(doc, { line: 3, character: 10 });
+
+      expect(explicitLocal).toHaveLength(1);
+      expect(explicitLocal[0]?.range.start).toEqual({ line: 2, character: 11 });
+      expect(read).toHaveLength(1);
+      expect(read[0]?.range.start).toEqual({ line: 2, character: 11 });
+    });
+  });
+});

--- a/tests/symbol-tree-invariants.test.ts
+++ b/tests/symbol-tree-invariants.test.ts
@@ -1,0 +1,181 @@
+import { analyzer, Analyzer } from '../src/analyze';
+import { initializeParser } from '../src/parser';
+import { equalSymbolDefinitions, equalSymbols, equalSymbolScopes, symbolContainsScope } from '../src/parsing/equality-utils';
+import { FishSymbol } from '../src/parsing/symbol';
+import { setupProcessEnvExecFile } from '../src/utils/process-env';
+import { setLogger } from './helpers';
+import TestWorkspace from './test-workspace-utils';
+
+/**
+ * Structural invariants of the FishSymbol tree and its equality predicates.
+ *
+ * These exist because a scope predicate was once built on the assumption that
+ * "only functions are internal nodes in the FishSymbol tree" — which had been
+ * false since FOR symbols began nesting their body's definitions — and no test
+ * failed. Any change to which fishKinds parent other symbols, or to the
+ * reflexivity/symmetry of the equality predicates, should fail loudly here.
+ */
+describe('symbol tree invariants', () => {
+  setLogger();
+
+  beforeEach(async () => {
+    await setupProcessEnvExecFile();
+    await initializeParser();
+    await Analyzer.initialize();
+    await setupProcessEnvExecFile();
+  });
+
+  const workspace = TestWorkspace.create().addFiles({
+    relativePath: 'shape.fish',
+    content: [
+      'function shape',
+      '    set -f body_var 1',
+      '    for i in (seq 3)',
+      '        set -a body_var $i',
+      '        set -l loop_var $i',
+      '    end',
+      '    while test -n "$body_var"',
+      '        set -l while_var 1',
+      '    end',
+      '    if test -z "$body_var"',
+      '        set -l if_var 1',
+      '    end',
+      '    set -f sub_var (begin; set -l sub_inner 1; end)',
+      '    function shape_inner',
+      '        set -f inner_var 1',
+      '    end',
+      'end',
+    ].join('\n'),
+  }, {
+    relativePath: 'predicates.fish',
+    content: [
+      'set -gx GLOBAL_VAR 1',
+      'set file_var 2',
+      'function pred_outer',
+      '    set -f fn_var 1',
+      '    set -a fn_var 2',
+      '    set -ef fn_var',
+      '    set -f fn_var 3',
+      '    for i in (seq 2)',
+      '        set -l shadow $i',
+      '    end',
+      '    function pred_inner --no-scope-shadowing',
+      '        set -a fn_var 4',
+      '    end',
+      'end',
+      "alias pred_alias 'echo hi'",
+    ].join('\n'),
+  }).initialize();
+
+  const allSymbols = (): FishSymbol[] => [
+    ...analyzer.getFlatDocumentSymbols(workspace.getDocument('shape.fish')!.uri),
+    ...analyzer.getFlatDocumentSymbols(workspace.getDocument('predicates.fish')!.uri),
+  ];
+
+  const describeSymbol = (symbol: FishSymbol): string =>
+    `${symbol.name}:${symbol.fishKind}@${symbol.selectionRange.start.line}:${symbol.selectionRange.start.character}`;
+
+  describe('tree shape', () => {
+    it('parents definitions under the fishKinds that actually nest', () => {
+      const doc = workspace.getDocument('shape.fish')!;
+      const flat = analyzer.getFlatDocumentSymbols(doc.uri);
+
+      const bodyVars = flat.filter(s => s.name === 'body_var' && s.fishKind === 'SET');
+      expect(bodyVars.map(s => s.parent?.fishKind).sort()).toEqual(['FOR', 'FUNCTION']);
+
+      const loopVar = flat.find(s => s.name === 'loop_var')!;
+      expect(loopVar.parent?.fishKind).toBe('FOR');
+
+      // while/if blocks are NOT internal nodes: their definitions bubble up to
+      // the enclosing function symbol
+      const whileVar = flat.find(s => s.name === 'while_var')!;
+      const ifVar = flat.find(s => s.name === 'if_var')!;
+      expect(whileVar.parent?.fishKind).toBe('FUNCTION');
+      expect(ifVar.parent?.fishKind).toBe('FUNCTION');
+
+      // a definition inside a command substitution nests under the SET symbol
+      const subInner = flat.find(s => s.name === 'sub_inner')!;
+      expect(subInner.parent?.fishKind).toBe('SET');
+      expect(subInner.parent?.name).toBe('sub_var');
+    });
+
+    it('only the expected fishKinds appear as internal nodes', () => {
+      const internalKinds = new Set(
+        allSymbols()
+          .filter(symbol => symbol.children.length > 0)
+          .map(symbol => symbol.fishKind),
+      );
+
+      expect([...internalKinds].sort()).toEqual(['FOR', 'FUNCTION', 'SET']);
+    });
+
+    it('reports the enclosing function as owner regardless of nesting depth', () => {
+      const doc = workspace.getDocument('shape.fish')!;
+      const flat = analyzer.getFlatDocumentSymbols(doc.uri);
+
+      const shape = flat.find(s => s.name === 'shape' && s.fishKind === 'FUNCTION')!;
+      const shapeInner = flat.find(s => s.name === 'shape_inner')!;
+
+      expect(shape.getFunctionOwner()).toBeUndefined();
+      expect(shapeInner.getFunctionOwner()?.id).toBe(shape.id);
+
+      for (const name of ['body_var', 'loop_var', 'while_var', 'if_var', 'sub_var', 'sub_inner']) {
+        const owned = flat.filter(s => s.name === name);
+        expect(owned.length).toBeGreaterThan(0);
+        for (const symbol of owned) {
+          expect(symbol.getFunctionOwner()?.id).toBe(shape.id);
+        }
+      }
+
+      const innerVar = flat.find(s => s.name === 'inner_var')!;
+      expect(innerVar.getFunctionOwner()?.id).toBe(shapeInner.id);
+    });
+  });
+
+  describe('equality predicate properties', () => {
+    it('every predicate is reflexive for every symbol', () => {
+      const failures: string[] = [];
+      for (const symbol of allSymbols()) {
+        if (!equalSymbols(symbol, symbol)) failures.push(`equalSymbols ${describeSymbol(symbol)}`);
+        if (!equalSymbolScopes(symbol, symbol)) failures.push(`equalSymbolScopes ${describeSymbol(symbol)}`);
+        if (!symbolContainsScope(symbol, symbol)) failures.push(`symbolContainsScope ${describeSymbol(symbol)}`);
+        if (!equalSymbolDefinitions(symbol, symbol)) failures.push(`equalSymbolDefinitions ${describeSymbol(symbol)}`);
+      }
+      expect(failures).toEqual([]);
+    });
+
+    it('equalSymbols and equalSymbolScopes are symmetric over all pairs', () => {
+      const symbols = allSymbols();
+      const failures: string[] = [];
+      for (const a of symbols) {
+        for (const b of symbols) {
+          if (equalSymbols(a, b) !== equalSymbols(b, a)) {
+            failures.push(`equalSymbols ${describeSymbol(a)} vs ${describeSymbol(b)}`);
+          }
+          if (equalSymbolScopes(a, b) !== equalSymbolScopes(b, a)) {
+            failures.push(`equalSymbolScopes ${describeSymbol(a)} vs ${describeSymbol(b)}`);
+          }
+        }
+      }
+      expect(failures).toEqual([]);
+    });
+
+    it('keeps erase-separated re-definitions unequal while merging same-chain writes', () => {
+      const doc = workspace.getDocument('predicates.fish')!;
+      const fnVars = analyzer.getFlatDocumentSymbols(doc.uri)
+        .filter(s => s.name === 'fn_var' && s.fishKind === 'SET' && s.parent?.name === 'pred_outer')
+        .sort((a, b) => a.selectionRange.start.line - b.selectionRange.start.line);
+
+      // `set -ef` produces no definition symbol, so pred_outer owns exactly:
+      // line 3 (first binding), line 4 (append to it), line 6 (post-erase binding)
+      expect(fnVars.map(s => s.selectionRange.start.line)).toEqual([3, 4, 6]);
+      const [first, append, postErase] = fnVars as [FishSymbol, FishSymbol, FishSymbol];
+
+      expect(equalSymbolDefinitions(first, append)).toBe(true);
+      // Guards against "fixing" predicate reflexivity via scope-node equality:
+      // these two share a scope node but sit in different binding lifetimes
+      expect(equalSymbolDefinitions(first, postErase)).toBe(false);
+      expect(equalSymbolDefinitions(append, postErase)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
* Definitions of variables weren't resolving to correct locations, first introduced by change in `1.1.4-pre.3` (still present in `1.1.4` && `1.1.5-pre.0`)

  **Example:** ```fish function my_func set var for i in (seq 10) set -a var $i # goto-def not moving to outer var end end ```

* `symbol.getFunctionOwner()` is now used to determine which lexical symbol contains the enclosing parent scope of a variable symbol, which groups overlapping definitions & references into their outermost owner function symbol

  **NOTE:** previously referred to as `getEnclosingFunction()`

* Variables with the same function owner but different lexical scopes resolve correctly. Function ownership is only the first boundary; scope tag and scopeNode distinguish sibling locals and nested shadows.

  **Tests verify:**
  - same-scope redefinitions resolve to the first definition
  - sibling explicit locals remain independent despite sharing a function owner
  - nested shadows apply only inside their block
  - outer bindings are restored after the nested scope
  - nested and root same-named functions resolve independently
  - event hooks and repeated emitted events remain distinct definition sites
  - root and nested ownership behavior for functions, variables, and events
  - `--no-scope-shadowing` and `--inherit-variable`, including multi-hop calls

* root functions, variables, and emitted events return undefined

============
fix(parsing): make scope predicates reflexive at source + pin tree invariants

* follow-up hardening for the `1.1.4-pre.3` goto-def regression fix (`4cf8e9f2`), intended to be squashed into it

* fix(equality-utils): reflexivity moved into `haveEqualScopes`, replacing the per-entry-point shims in `equalSymbolDefinitions`/`equalSymbolScopes`

  - the containment fallbacks are lifetime-aware (`scopeContainsNode` applies the strict before-definition rule), so a definition's own command node — which starts at the `set`/`read` keyword, before its name token — was rejected by them, making `equalSymbolScopes(x, x) === false` possible

  - compares definition sites (`equalSymbols`), NOT scope nodes: erase-separated re-definitions share a scope node but are distinct bindings and must stay unequal

  - protects every `symbolContainsScope` caller, not just the two entry points that happened to be shimmed

* docs: `symbolContainsScope` guard sequence documented as load-bearing (owner guard → explicit-scope guard → equal-scopes shortcut → positional fallbacks); `getFunctionOwner()` notes why the walk stops at `FUNCTION` but never `ALIAS`

* test(duplicate-variable-definition): cover the mundane list-building idioms the release regression shipped through untested

  **Tests verify:**
  - `set -a`/`set -p` inside `while`/`if`/nested-`for` blocks resolve to the first definition in the function scope
  - `set -q var; or set var default` guards resolve to the fallback definition
  - definitions and reads inside command substitutions resolve correctly
  - `read` definitions in a `while` header resolve from the loop body

  **NOTE:** four tests pin behavior that diverges from fish and flips by file
  location: unscoped writes tag `local` in scripts but `function` in
  autoloaded files (`getFallbackModifierScope`), so which of `-l`/`-f` folds
  into the unscoped chain vs. starts a new definition site inverts per file
  kind — fish folds both (see the in-test comment before changing these)

* test(symbol-tree-invariants): new file asserting the structural premises the scope predicates rely on

  **Tests verify:**
  - internal `FishSymbol` tree nodes are exactly `FUNCTION`/`FOR`/`SET`, so the false "only functions are internal nodes" premise behind the original regression now fails loudly instead of shipping
  - `getFunctionOwner()` reporting across for/while/if/substitution nesting and for root symbols
  - all four equality predicates are reflexive over every fixture symbol; `equalSymbols`/`equalSymbolScopes` are symmetric over all pairs
  - erase-separated re-definitions stay unequal while same-chain writes merge (traps any future scope-node-equality "fix" for reflexivity)

* verified:
   - 26/26 `duplicate-variable-definition`
   - 6/6 `symbol-tree-invariants`,
   - 206 passing across the 8 predicate-adjacent suites; eslint + typecheck